### PR TITLE
Fixed alts in Language.vue

### DIFF
--- a/components/Language.vue
+++ b/components/Language.vue
@@ -4,7 +4,7 @@
 			<img
 				@click="locale = 'en-US'"
 				src="/images/en.webp"
-				alt="english translation"
+				alt="English translation"
 				class="transition duration-200 ease-out cursor-pointer w-4 h-4 rounded-3xl object-cover"
 				:class="locale == 'en-US' ? 'opacity-100' : 'opacity-60'"
 			/>
@@ -12,7 +12,7 @@
 			<img
 				@click="locale = 'de'"
 				src="/images/de.webp"
-				alt="french translation"
+				alt="German translation"
 				class="transition duration-200 ease-out cursor-pointer w-4 h-4 rounded-3xl object-cover"
 				:class="locale == 'de' ? 'opacity-100' : 'opacity-60'"
 			/>


### PR DESCRIPTION
The alt for German was for French(and French isn't even in the file (yet)) and the names for languages are now in uppercase

## Description
<!-- Please provide a summary of the change and include relevant motivation and context. -->
I was looking at the translation files and how it works a bit and I saw that the alt for German is "french translation" and it was in lowercase. It shouldn't break anything

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Translation updates (fix/improve or add new translations)


<!-- To receive a reward for contributing, enter the username of your Bootstrap Academy account -->
My Bootstrap Academy username: Onako2
