### PR TITLE
show top menu in leader-board #52

### DIFF
--- a/pages/challenges/leader-board.vue
+++ b/pages/challenges/leader-board.vue
@@ -51,7 +51,6 @@
 import { useI18n } from "vue-i18n";
 import { useLeaderBoardList } from "~~/composables/leaderboard";
 definePageMeta({
-  layout: "inner",
   middleware: ["auth"],
 });
 


### PR DESCRIPTION
## Description
removed "inner" Layout-Tag from leader-board to show the usual top menu
https://github.com/Bootstrap-Academy/Bootstrap-Academy/issues/52

![grafik](https://github.com/Bootstrap-Academy/frontend/assets/75255380/b7d31513-ea7b-4bd5-907d-fd3223d49bad)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Translation updates (fix/improve or add new translations)

<!-- Replace ISSUE-NUMBER with the id of the ticket this PR is supposed to solve -->
Fixes Bootstrap-Academy/Bootstrap-Academy#52

<!-- To receive a reward for contributing, enter the username of your Bootstrap Academy account -->
My Bootstrap Academy username: vim
