### PR TITLE
Remove inner container scrolling in leaderboard

### DIFF
--- a/components/leaderboard/ChallengeBased.vue
+++ b/components/leaderboard/ChallengeBased.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-[80vh] overflow-y-scroll px-7">
+  <div class="px-7">
     <SkeletonLeaderBoardChallenges v-if="loading" />
     <section
       v-else-if="!loading && allGlobalChallenges.length"

--- a/components/leaderboard/Listing.vue
+++ b/components/leaderboard/Listing.vue
@@ -18,7 +18,7 @@
           v-if="!!leaderBoardList[2]"
         />
       </article>
-      <article class="max-h-[80vh] overflow-y-scroll px-3 pb-24 sm:px-10">
+      <article class="px-3 pb-24 sm:px-10">
         <div v-for="(user, i) of leaderBoardList" :key="i">
           <LeaderboardUserCard v-if="user.rank > 3" :item="user" />
         </div>
@@ -27,6 +27,7 @@
 
     <div class="flex justify-center mt-6">
       <InputBtn
+      v-if="leaderBoardList.length < totalLeaderboardUsers"
         :loading="btnLoading"
         @click="loadMore()"
         :icon="TrophyIcon"
@@ -36,14 +37,15 @@
             btnLoading || leaderBoardList.length >= totalLeaderboardUsers,
         }"
       >
-        <div v-if="leaderBoardList.length < totalLeaderboardUsers">
+        <div>
           {{ t("Headings.More") }}
-        </div>
-        <div v-else>
-          {{ t("Headings.NoMoreUser") }}
         </div>
       </InputBtn>
     </div>
+    <p v-if="leaderBoardList.length == totalLeaderboardUsers" class="flex flex-col items-center text-accent">      
+      <component v-if="TrophyIcon" :is="TrophyIcon" class="w-10 h-10 bg-primary mb-4"/>
+      {{ t("Headings.NoMoreUser") }}
+    </p>
   </div>
 </template>
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -53,7 +53,7 @@
     "PremiumEndsIn": "Dein Premium-Abonnement endet",
     "ButAdditionalSubscription": "Wenn Du ein zusätzliches Abonnement erwirbst, wird die Laufzeit deines bestehenden Abonnements verlängert.",
     "More": "mehr",
-    "NoMoreUser": "Keine Benutzer mehr",
+    "NoMoreUser": "Es gibt keine weiteren Benutzer",
     "PowerPoint": "PowerPoint",
     "Quizzes": "Quizze",
     "ClickForExampleCode": "Klicke auf „Für Beispielcode“.",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -52,7 +52,7 @@
     "ButAdditionalSubscription": "Buying an additional subscription will be added with your previous subscription duration",
     "PremiumEndsIn": "Your premium subscription ends",
     "More": "More",
-    "NoMoreUser": "No More Users",
+    "NoMoreUser": "There are no more users",
     "Rank": "Rank",
     "HTML": "Html",
     "Excel": "Excel",


### PR DESCRIPTION
## Description
I removed the inner scolling, when hovering on the leaderboard container and made it a page-wide scrolling, as suggested in https://github.com/Bootstrap-Academy/Bootstrap-Academy/issues/116 .

I have also changed the design if you scroll to the end in the list of leaders
![image](https://github.com/Bootstrap-Academy/frontend/assets/84938977/d762a77e-f45f-4b62-84ab-d244ed2654d4)

- [x] Coding Language Based Tab
- [x] Challenge Based Tab
- [x] Over All Tab


@TheMorpheus407 Is this the change you wanted to achieve with the issue?


My Bootstrap Academy username: Lauritz
