### PR TITLE
Issue#109: Keep the time of a video when switching to questions and back

### DIFF
--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -20,7 +20,7 @@
       allowfullscreen
       controlsList="nodownload"
       oncontextmenu="return false;"
-      :key="`video-${activeLecture.id}`"
+      :key="`video-${videoSRC}`"
       @timeupdate="onTimeUpdate(activeLecture.id, $event)"
       @loadstart="onVideoLoad(activeLecture.id, $event)"
     >    

--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -108,15 +108,12 @@ export default defineComponent({
     
       if (videoCookie.value !== videoID) {
         // Reset the time cookie to start the new video from the beginning
-        timeCookie.value = 0;
+        timeCookie.value = "";
         videoCookie.value = videoID;
       } else {
         // Set the current video time to the saved cookie value
         event.target.currentTime = timeCookie.value;
       }
-    }
-    
-      event.target.currentTime = timeCookie.value;
     }
     
     return { videoSRC, refSource, onTimeUpdate, onVideoLoad };

--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -97,7 +97,7 @@ export default defineComponent({
       const currentVideoTime = event.target.currentTime;
       timeCookie.value = currentVideoTime;
     
-      if (currentVideoTime > 0) videoCookie.value = videoID;
+      if (currentVideoTime < 1) videoCookie.value = videoID;
     }
     
     function onVideoLoad(videoID: string, event: any) {

--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -11,6 +11,7 @@
     ></iframe>
 
     <video
+      ref="video"
       v-else-if="activeLecture.type == 'mp4'"
       :poster="course.image"
       controls
@@ -54,6 +55,7 @@ export default defineComponent({
     const videoSRC = useVideoSRC();
 
     let videoInterval: any;
+    const video = ref<HTMLVideoElement | null>(null); 
     const refSource = ref<HTMLSourceElement | any>(null);
 
     watch(
@@ -73,9 +75,15 @@ export default defineComponent({
           refSource.value.setAttribute("src", videoSRC.value);
           videoInterval = setInterval(async () => {
             await getLectureVideoSRC(courseID, newValue);
+            if (video.value) {
+              video.value.pause();
+              refSource.value.src = videoSRC.value;
+              video.value.load();
+              video.value.play();
+            };
             // refSource.value.setAttribute('src', videoSRC.value);
             refSource.value.src = videoSRC.value;
-          }, 40000);
+          }, 28800000); //8 hours
         }
       },
       { deep: true, immediate: true }
@@ -96,13 +104,17 @@ export default defineComponent({
       const videoCookie = useCookie("currentVideo");
       const timeCookie = useCookie("currentVideoTime");
     
-      if (!videoCookie || videoCookie.value == "" || !timeCookie || timeCookie.value == "") return;
+      if (!videoCookie || videoCookie.value === "" || !timeCookie || timeCookie.value === "") return;
     
       if (videoCookie.value !== videoID) {
-        videoCookie.value = "";
-        timeCookie.value = "";
-        return;
+        // Reset the time cookie to start the new video from the beginning
+        timeCookie.value = 0;
+        videoCookie.value = videoID;
+      } else {
+        // Set the current video time to the saved cookie value
+        event.target.currentTime = timeCookie.value;
       }
+    }
     
       event.target.currentTime = timeCookie.value;
     }


### PR DESCRIPTION
## Description
<!-- Please provide a summary of the change and include relevant motivation and context. -->
Added code to keep the current time of a selfhosted video when switching to questions and back. This was resolved by saving the currenttime and currentvideoID as a cookie and comparing if the saved ID is the same as the ID of the playing Video before setting the time of the video to the stored value.
 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Translation updates (fix/improve or add new translations)

<!-- Replace ISSUE-NUMBER with the id of the ticket this PR is supposed to solve -->
Fixes Bootstrap-Academy/Bootstrap-Academy#109

<!-- To receive a reward for contributing, enter the username of your Bootstrap Academy account -->
My Bootstrap Academy username: R4bbit
