### PR TITLE
Academy cleanup

### DIFF
--- a/components/Btn.vue
+++ b/components/Btn.vue
@@ -1,13 +1,11 @@
 <template>
-  <button :class="classes" @click="onclick" type="button">
-    <component v-if="icon" :is="icon" class="icon"></component>
+  <button :class="classes" @click="onclick" :disabled="disabled" type="button">
+    <component v-if="icon" :is="icon" class="icon" />
     <slot></slot>
   </button>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
-
 export default defineComponent({
   props: {
     full: { type: Boolean, default: false },
@@ -21,11 +19,12 @@ export default defineComponent({
     iconRight: { type: Boolean, default: false },
     bgColor: { type: String, default: "bg-accent" },
     borderColor: { type: String, default: "border-accent" },
+    disabled: { type: Boolean, default: false },
   },
   emits: ["click"],
   setup(props, { emit }) {
     function onclick() {
-      emit("click", true);
+      if (!props.disabled) emit("click", true);
     }
 
     const textColor = computed(() => {
@@ -39,15 +38,16 @@ export default defineComponent({
           sm: props.sm,
           "flex-row-reverse": props.iconRight,
           "text-center justify-center w-full": props.full,
+          disabled: props.disabled,
         },
         props.primary && !props.secondary && !props.tertiary
-          ? `primary ${props.bgColor} text-primary hover:${props.bgColor} border ${props.borderColor} hover:ring-4 md:hover:ring-8 hover:ring-tertiary`
+          ? `primary ${props.bgColor} text-primary enabled:hover:${props.bgColor} border ${props.borderColor} enabled:hover:ring-4 md:enabled:hover:ring-8 enabled:hover:ring-tertiary`
           : "",
         props.secondary
-          ? `secondary bg-transparent text-heading hover:bg-transparent border ${props.borderColor} hover:ring-4 md:hover:ring-8 hover:ring-tertiary`
+          ? `secondary bg-transparent text-heading enabled:hover:bg-transparent border ${props.borderColor} enabled:hover:ring-4 md:enabled:hover:ring-8 enabled:hover:ring-tertiary`
           : "",
         props.tertiary
-          ? `tertiary bg-transparent text-heading hover:bg-transparent hover:scale-105 border border-transparent hover:ring-4 md:hover:ring-8 hover:ring-transparent`
+          ? `tertiary bg-transparent text-heading enabled:hover:bg-transparent enabled:hover:scale-105 border border-transparent enabled:hover:ring-4 md:enabled:hover:ring-8 enabled:hover:ring-transparent`
           : "",
       ];
     });
@@ -55,10 +55,15 @@ export default defineComponent({
   },
 });
 </script>
+
 <style scoped>
 button {
   @apply h-fit rounded flex items-center text-center
 			 uppercase tracking-widest transition-basic font-body;
+}
+
+button:disabled {
+  @apply opacity-50 cursor-not-allowed;
 }
 
 /* ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ STYLE */

--- a/components/SectionTitle.vue
+++ b/components/SectionTitle.vue
@@ -7,33 +7,35 @@
 		<p class="text-body-2 col-span-2 hidden md:block">{{ t(body) }}</p>
 	</header>
 
-	<header :class="{ 'text-center': center, 'max-w-xl': !full }" v-else>
-		<h1 v-if="size == 'xl'" class="mb-4 md:mb-6 text-display-2 leading-tight">
-			<strong class="text-subheading-1 mb-2 md:mb-4 block">
-				{{ t(subheading) }}
-			</strong>
-			{{ t(heading) }}
-		</h1>
+	<div v-else class="flex justify-center">
+		<header :class="{ 'text-center': center, 'max-w-xl': !full }">
+			<h1 v-if="size == 'xl'" class="mb-4 md:mb-6 text-display-2 leading-tight">
+				<strong class="text-subheading-1 mb-2 md:mb-4 block">
+					{{ t(subheading) }}
+				</strong>
+				{{ t(heading) }}
+			</h1>
 
-		<h1 v-else-if="size == 'lg'" class="mb-5 text-heading-1">
-			<strong class="text-subheading-1 mb-2 block">{{ t(subheading) }}</strong>
-			{{ t(heading) }}
-		</h1>
-		
-		<h3 v-else-if="size == 'sm'" class="mb-2 text-heading-2">
-			<strong class="text-xs md:text-sm mb-2 text-accent block">
-				{{ t(subheading) }}
-			</strong>
-			{{ t(heading) }}
-		</h3>
-		<h2 v-else class="mb-box leading-normal text-heading-1">
-			<strong class="text-subheading-1 mb-1 xl:mb-2 block">
-				{{ t(subheading) }}
-			</strong>
-			{{ t(heading) }}
-		</h2>
-		<p>{{ t(body) }}</p>
-	</header>
+			<h1 v-else-if="size == 'lg'" class="mb-5 text-heading-1">
+				<strong class="text-subheading-1 mb-2 block">{{ t(subheading) }}</strong>
+				{{ t(heading) }}
+			</h1>
+			
+			<h3 v-else-if="size == 'sm'" class="mb-2 text-heading-2">
+				<strong class="text-xs md:text-sm mb-2 text-accent block">
+					{{ t(subheading) }}
+				</strong>
+				{{ t(heading) }}
+			</h3>
+			<h2 v-else class="mb-box leading-normal text-heading-1">
+				<strong class="text-subheading-1 mb-1 xl:mb-2 block">
+					{{ t(subheading) }}
+				</strong>
+				{{ t(heading) }}
+			</h2>
+			<p>{{ t(body) }}</p>
+		</header>
+	</div>
 </template>
 
 <script lang="ts">

--- a/components/Tooltip.vue
+++ b/components/Tooltip.vue
@@ -82,7 +82,7 @@ function show() {
       @mouseleave="hide"
       ref="floatingRef"
       :class="[
-        ' absolute w-max max-w-[380px] text-sm top-0 left-0 z-50 bg-light text-subheading p-3  rounded-md cursor-default',
+        'absolute w-max max-w-[calc(100vw-50px)] sm:max-w-[380px] text-sm top-0 left-0 z-50 bg-light text-subheading p-3 rounded-md cursor-default',
         isHidden && 'hidden',
       ]"
     >

--- a/components/course/VideoControls.vue
+++ b/components/course/VideoControls.vue
@@ -3,6 +3,7 @@
     <article class="flex midXl:hidden gap-card items-center">
       <div class="flex gap-2">
         <ArrowLeftCircleIcon
+          v-if="!isFirstLecture"
           @click="goToPrevLecture"
           class="w-10 h-10 text-accent cursor-pointer"
         />
@@ -14,7 +15,7 @@
     </article>
     <!-- pr-[70px] -->
     <article class="hidden midXl:flex gap-box items-center">
-      <Btn sm tertiary @click="goToPrevLecture" :icon="ArrowLeftIcon">
+      <Btn v-if="!isFirstLecture" sm tertiary @click="goToPrevLecture" :icon="ArrowLeftIcon">
         {{ t("Buttons.Prev") }}
       </Btn>
       <Btn sm @click="goToNextLecture" :icon="ArrowRightIcon" icon-right>
@@ -43,6 +44,10 @@ const props = defineProps({
 const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
+
+const isFirstLecture = computed(() => lectures.value.findIndex(
+  (lecture) => lecture.id == activeLectureID.value
+) <= 0);
 
 const activeLectureID = computed(() => {
   return props.activeLecture?.id ?? "";

--- a/components/course/VideoMeta.vue
+++ b/components/course/VideoMeta.vue
@@ -4,7 +4,7 @@
   >
     <div class="flex flex-wrap items-center">
       <NuxtLink :to="path" class="flex">
-        <span class="max-w-[200px] clamp"> {{ course?.title ?? "" }} </span>
+        <span class="max-w-max clamp"> {{ course?.title ?? "" }} </span>
         <span>/</span>
       </NuxtLink>
 

--- a/components/course/VideoMeta.vue
+++ b/components/course/VideoMeta.vue
@@ -33,7 +33,7 @@
           listOfCompletedCourses.find((lec) => lec == activeLecture.id)
         "
       >
-        <Btn i-if="user?.admin || canCreate" secondary sm @click="addTask">{{ t("Buttons.AddTask") }}</Btn>
+        <Btn i-if="user?.admin || canCreate" :icon="PlusCircleIcon" secondary sm @click="addTask">{{ t("Buttons.AddTask") }}</Btn>
       </template>
 
       <Btn
@@ -74,12 +74,13 @@
 <script lang="ts">
 import { useI18n } from "vue-i18n";
 import { defineComponent, ref, computed, onMounted } from "vue";
-import { CheckIcon, CheckBadgeIcon } from "@heroicons/vue/24/solid";
+import { CheckIcon, CheckBadgeIcon, PlusCircleIcon } from "@heroicons/vue/24/solid";
 
 export default defineComponent({
   components: {
     CheckIcon,
     CheckBadgeIcon,
+    PlusCircleIcon,
   },
   props: {
     course: { type: Object as PropType<any>, default: null },
@@ -207,6 +208,7 @@ export default defineComponent({
       path,
       listOfCompletedCourses,
       CheckIcon,
+      PlusCircleIcon,
       markLectureAsComplete,
       activeLectureID,
       courseID,

--- a/components/input/ButtonToggle.vue
+++ b/components/input/ButtonToggle.vue
@@ -1,31 +1,21 @@
 <template>
-	<div
-		:class="[
-			!!mobileResponsive ? 'flex-col rounded-lg sm:flex-row sm:rounded-full' : 'rounded-full',
-			!!primary && !secondary ? 'bg-primary border border-accent' : '',
-			secondary ? 'border border-light' : '',
-		]"
-		class="flex gap-3 p-2 w-fit"
-	>
-		<section
-			@click="emitSelected(i)"
-			v-for="(button, i) of options"
-			:key="i"
-		>
-			<p
-				class="text-black text-xs sm:text-sm px-2 sm:px-6 md:px-8 cursor-pointer capitalize transition-all duration-300 font-semibold py-2 rounded-full"
+	<div :class="[
+		!!mobileResponsive ? 'flex-col rounded-lg sm:flex-row sm:rounded-full' : 'rounded-full',
+		!!primary && !secondary ? 'bg-primary border border-accent' : '',
+		secondary ? 'border border-light' : '',
+	]" class="flex gap-3 p-2 w-fit">
+		<section v-for="(button, i) of options" :key="i" @click="!button.disabled ? emitSelected(i) : null">
+			<p class="text-black text-xs sm:text-sm px-2 sm:px-6 md:px-8 cursor-pointer capitalize transition-all duration-300 font-semibold py-2 rounded-full"
 				:class="[
 					{
 						'px-2.5': smInMobile,
 						'px-4': !smInMobile,
 					},
-					selectedOption == i && primary && !!!secondary ? 'bg-accent' : 'text-white',
-
-					selectedOption == i && secondary ? 'bg-light ' : '',
-
-					!!mobileResponsive ? 'rounded-lg sm:flex-row sm:rounded-full' : 'rounded-full',
-				]"
-			>
+					selectedOption == i && primary && !secondary ? 'bg-accent' : 'text-white',
+					selectedOption == i && secondary ? 'bg-light' : '',
+					button.disabled ? 'opacity-50' : '',
+					mobileResponsive ? 'rounded-lg sm:flex-row sm:rounded-full' : 'rounded-full',
+				]">
 				{{ t(button.name) }}
 			</p>
 		</section>
@@ -34,35 +24,45 @@
 
 <script lang="ts" setup>
 import { useI18n } from "vue-i18n";
-	  const props=defineProps({
-	    modelValue: { type: Number, default: 0 },
-	    buttonOptions: { type: Array as PropType<any>, default: [] },
-	    primary: { type: Boolean, default: true },
-	    secondary: { type: Boolean, default: false },
-	    mobileResponsive: { type: Boolean, default: true },
-	    smInMobile: { type: Boolean, default: false },
-	  })
+const props = defineProps({
+	modelValue: { type: Number, default: 0 },
+	buttonOptions: { type: Array as PropType<any>, default: [] },
+	primary: { type: Boolean, default: true },
+	secondary: { type: Boolean, default: false },
+	mobileResponsive: { type: Boolean, default: true },
+	smInMobile: { type: Boolean, default: false },
+})
 
-	 	const emits=defineEmits(["update:modelValue"])
-	    const { t } = useI18n();
-	    const selectedOption = ref(0);
+const emits = defineEmits(["update:modelValue"])
+const { t } = useI18n();
+const selectedOption = ref(0);
 
 const options = computed(() => props.buttonOptions)
 
-
-
 watch(
-  () => props.modelValue,
-  (newValue, oldValue) => {
-    selectedOption.value = newValue;
-  },
-  { immediate: true }
+	() => props.modelValue,
+	(newValue, oldValue) => {
+		selectedOption.value = newValue;
+		if (options.value[selectedOption.value]?.disabled) {
+			selectedOption.value = 0;
+			emits("update:modelValue", 0);
+		}
+	},
+	{ immediate: true }
 );
 
-	    function emitSelected(selected: any) {
-	      selectedOption.value = selected;
-	      emits("update:modelValue", selected);
-	    }
-</script>
+watch(
+	() => options.value,
+	(newOptions) => {
+		if (newOptions[selectedOption.value]?.disabled) {
+			selectedOption.value = 0;
+			emits("update:modelValue", 0);
+		}
+	}
+);
 
-<style scoped></style>
+function emitSelected(selected: any) {
+	selectedOption.value = selected;
+	emits("update:modelValue", selected);
+}
+</script>

--- a/components/input/ButtonToggle.vue
+++ b/components/input/ButtonToggle.vue
@@ -25,12 +25,12 @@
 <script lang="ts" setup>
 import { useI18n } from "vue-i18n";
 const props = defineProps({
-	modelValue: { type: Number, default: 0 },
-	buttonOptions: { type: Array as PropType<any>, default: [] },
-	primary: { type: Boolean, default: true },
-	secondary: { type: Boolean, default: false },
-	mobileResponsive: { type: Boolean, default: true },
-	smInMobile: { type: Boolean, default: false },
+  modelValue: { type: Number, default: 0 },
+  buttonOptions: { type: Array as PropType<any>, default: [] },
+  primary: { type: Boolean, default: true },
+  secondary: { type: Boolean, default: false },
+  mobileResponsive: { type: Boolean, default: true },
+  smInMobile: { type: Boolean, default: false },
 })
 
 const emits = defineEmits(["update:modelValue"])
@@ -40,29 +40,29 @@ const selectedOption = ref(0);
 const options = computed(() => props.buttonOptions)
 
 watch(
-	() => props.modelValue,
-	(newValue, oldValue) => {
-		selectedOption.value = newValue;
-		if (options.value[selectedOption.value]?.disabled) {
-			selectedOption.value = 0;
-			emits("update:modelValue", 0);
-		}
-	},
-	{ immediate: true }
+  () => props.modelValue,
+  (newValue, oldValue) => {
+    selectedOption.value = newValue;
+    if (options.value[selectedOption.value]?.disabled) {
+      selectedOption.value = 0;
+      emits("update:modelValue", 0);
+    }
+  },
+  { immediate: true }
 );
 
 watch(
-	() => options.value,
-	(newOptions) => {
-		if (newOptions[selectedOption.value]?.disabled) {
-			selectedOption.value = 0;
-			emits("update:modelValue", 0);
-		}
-	}
+  () => options.value,
+  (newOptions) => {
+    if (newOptions[selectedOption.value]?.disabled) {
+      selectedOption.value = 0;
+      emits("update:modelValue", 0);
+    }
+  }
 );
 
 function emitSelected(selected: any) {
-	selectedOption.value = selected;
-	emits("update:modelValue", selected);
+  selectedOption.value = selected;
+  emits("update:modelValue", selected);
 }
 </script>

--- a/components/matching/List.vue
+++ b/components/matching/List.vue
@@ -17,5 +17,3 @@ const props = defineProps({
 const matchings = useMatchings();
 
 </script>
-
-<style scoped></style>

--- a/components/skill-tree/Header.vue
+++ b/components/skill-tree/Header.vue
@@ -19,10 +19,14 @@
     </div>
 
     <NuxtLink
-      v-if="quizzesQuickStart && lastViewCourse"
+      v-if="quizzesQuickStart && lastViewCourse && lastViewCourseInfo.existing"
       :to="`/quizzes/solve-${lastViewCourse.courseId}?quizzesFrom=course&rootSkillID=${lastViewCourse.skillID}&subSkillID=${lastViewCourse.subSkillID}`"
     >
-      <Btn>{{ t("Headings.ViewQuizzesForLastViewCourse") }}</Btn>
+      <Btn>
+        {{ t("Headings.ViewQuizzesForLastViewCourse", {
+          type: t(lastViewCourseInfo.type)
+        }) }}
+      </Btn>
     </NuxtLink>
 
     <SkillTreeZoomLevel
@@ -49,9 +53,19 @@ export default defineComponent({
     const { t } = useI18n();
     const lastViewCourse: any = useCookie("lastViewCourse");
 
-    return { emit, t, lastViewCourse };
+    const lastViewCourseInfo = computed(() => {
+      let quizzes = useQuizzesInCourse();
+      let matchings = useMatchingsInCourse();
+
+      return {
+        existing: (
+          quizzes.value.length > 0 || matchings.value.length > 0
+        ),
+        type: quizzes.value.length > 0 ? "Headings.Quizzes" : "Headings.Matchings", 
+      }
+    });
+
+    return { emit, t, lastViewCourse, lastViewCourseInfo };
   },
 });
 </script>
-
-<style scoped></style>

--- a/components/skill-tree/NodeDetailsStepper.vue
+++ b/components/skill-tree/NodeDetailsStepper.vue
@@ -1,27 +1,13 @@
 <template>
   <article class="flex flex-col gap-card w-full h-fit">
-    <div v-for="{ level, label, bgColor, borderColor } of steppers">
-      <Btn full v-if="level == 3" :key="3" @click="openQuiz(
-        quizzes[0].id,
-      )" :secondary="_activeStepper != level" :bgColor="bgColor" :borderColor="borderColor">
-        {{ t(label) }}
-      </Btn>
-      <Btn full v-else-if="level == 4" :key="5" @click="openMatchings(
-          matchings[0].id,
-          matchings[0].task_id,
-        )" :secondary="_activeStepper != level" :bgColor="bgColor" :borderColor="borderColor">
-        {{ t(label) }}
-      </Btn>
-      <Btn full v-else :key="level" @click="_activeStepper = level" :secondary="_activeStepper != level"
-        :bgColor="bgColor" :borderColor="borderColor">
-        {{ t(label) }}
-      </Btn>
-    </div>
+    <Btn v-for="{ level, label, bgColor, borderColor, disabled, handleSelectStepper } of steppers" full :key="level"
+      :bgColor="bgColor" :borderColor="borderColor" @click="handleSelectStepper" :secondary="_activeStepper !== level" :disabled="disabled">
+      {{ t(label) }}
+    </Btn>
   </article>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
 import { useI18n } from "vue-i18n";
 
 export default defineComponent({
@@ -30,6 +16,11 @@ export default defineComponent({
     activeStepper: { default: 0 },
     skillID: { default: "" },
     subSkillID: { default: "" },
+    courses: { type: Array, default: () => [] },
+    coachings: { type: Array, default: () => [] },
+    webinars: { type: Array, default: () => [] },
+    quizzes: { type: Array, default: () => [] },
+    matchings: { type: Array, default: () => [] },
   },
   emits: ["activeStepper"],
   setup(props, { emit }) {
@@ -39,36 +30,48 @@ export default defineComponent({
     const quizzes = useQuizzes();
     const matchings = useMatchings();
 
-    const steppers = reactive([
+    let _activeStepper = ref(0);
+
+    const steppers = computed(() => [
       {
         level: 0,
         label: "Headings.Courses",
         bgColor: "bg-accent",
         borderColor: "border-accent",
+        disabled: !props.courses || props.courses.length === 0,
+        handleSelectStepper: () => _activeStepper.value = 0,
       },
       {
         level: 1,
         label: "Headings.Coachings",
         bgColor: "bg-info",
         borderColor: "border-info",
+        disabled: !props.coachings || props.coachings.length === 0,
+        handleSelectStepper: () => _activeStepper.value = 1,
       },
       {
         level: 2,
         label: "Headings.Webinars",
         bgColor: "bg-warning",
         borderColor: "border-warning",
+        disabled: !props.webinars || props.webinars.length === 0,
+        handleSelectStepper: () => _activeStepper.value = 2,
       },
       {
         level: 3,
         label: "Headings.QuizQuestions",
         bgColor: "bg-error",
         borderColor: "border-error",
+        disabled: !props.quizzes || props.quizzes.length === 0,
+        handleSelectStepper: () => openQuiz(quizzes.value[0]?.id),
       },
       {
         level: 4,
         label: "Headings.Matchings",
         bgColor: "bg-success",
         borderColor: "border-success",
+        disabled: !props.matchings || props.matchings.length === 0,
+        handleSelectStepper: () => openMatchings(matchings.value[0]?.id, matchings.value[0]?.task_id),
       },
     ]);
 
@@ -84,11 +87,10 @@ export default defineComponent({
       );
     }
 
-    const _activeStepper = ref(props.activeStepper ?? 0);
-
     watch(
       () => _activeStepper.value,
-      (newValue, oldValue) => {
+      (newValue) => {
+        console.log("newValue", newValue);
         emit("activeStepper", newValue);
       },
       { deep: true }
@@ -98,5 +100,3 @@ export default defineComponent({
   },
 });
 </script>
-
-<style scoped></style>

--- a/composables/matching.ts
+++ b/composables/matching.ts
@@ -74,6 +74,22 @@ export async function getMatchingsInTask(task_id: any) {
   }
 }
 
+export async function getMatchingsInSkill(skillId: any) {
+  try {
+    const res = await GET(`/challenges/skills/${skillId}/tasks`);
+    const matchings = useMatchings();
+    matchings.value = res ?? [];
+    return [res, null];
+  } catch (error: any) {
+    let msg = error?.data?.error;
+    if (msg == "unverified") {
+      openSnackbar("error", "Error.VerifyToGetQuizzes");
+      return [null, error];
+    }
+    return [null, error];
+  }
+}
+
 export async function getMyMatchingsInTask(task_id: any, creator: any) {
   try {
     const response = await GET(`/challenges/tasks/${task_id}/matchings?creator=${creator}`);

--- a/composables/matching.ts
+++ b/composables/matching.ts
@@ -4,6 +4,7 @@ export const useMatchings = () => useState<Matching[]>("matchings", () => []);
 export const useMatchingsInLecture = () => useState<Matching[]>("matchingsInLecture", () => []);
 export const useMatching = () => useState<Matching>("matching", (): Matching => new Matching());
 export const useMatchingsForLectures = () => useState<MatchingForSections[]>("matchingForLectures", (): MatchingForSections[] => [] )
+export const useMatchingsInCourse = () => useState<Matching[]>("matchingsInCourse", () => []);
 
 export async function createMatching(body: any, task_id: any) {
   try {
@@ -141,15 +142,14 @@ export async function getMatchingsInLecture(lecture: string) {
 
 export async function getMatchingsInCourse(courseId: any, section_id: any = "", lecture_id: any = "") {
   try {
+    const matchingsInCourse = useMatchingsInCourse();
     if (!!!section_id && !!!lecture_id) {
       const res = await GET(`/challenges/courses/${courseId}/tasks`);
-      const quizzes = useQuizzes();
-      quizzes.value = res ?? [];
+      matchingsInCourse.value = res ?? [];
       return [res, null];
     } else {
       const res = await GET(`/challenges/courses/${courseId}/tasks?lecture_id=${lecture_id}&section_id=${section_id}`);
-      const quizzes = useQuizzes();
-      quizzes.value = res ?? [];
+      matchingsInCourse.value = res ?? [];
       return [res, null];
     }
   } catch (error: any) {

--- a/locales/de.json
+++ b/locales/de.json
@@ -797,8 +797,8 @@
     "SaveDescription": "Beschreibung speichern",
     "DeleteDescription": "Beschreibung löschen",
     "ManageDescription": "Beschreibung verwalten",
-    "SaveChallenge": "Herausforderung speichern",
-    "DeleteChallenge": "Herausforderung löschen",
+    "SaveChallenge": "Challenge speichern",
+    "DeleteChallenge": "Challenge löschen",
     "Close": "Schließen",
 
     "CreateChallenge": "Challenge erstellen",

--- a/locales/de.json
+++ b/locales/de.json
@@ -44,7 +44,7 @@
     "TotalQuizzesInLecture": "Quizze in dieser Vorlesung",
     "MyQuizzes": "Meine Quizze",
     "SolvedQuizzes": "Gelöste Quizze",
-    "ViewQuizzesForLastViewCourse": "Quizze für den zuletzt angesehenen Kurs anzeigen",
+    "ViewQuizzesForLastViewCourse": "Schau Dir die {type} Deines letzten Kurses an!",
     "NoQuizFoundForYouToSolve": "Es wurde kein Quiz zum Lösen gefunden",
     "NoMatchingFoundForYouToSolve": "Es wurde kein Matching zum Lösen gefunden",
     "Rank": "Rang",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -47,7 +47,7 @@
     "TotalQuizzesInLecture": "Quizzes in this lecture",
     "MyQuizzes": "My Quizzes",
     "SolvedQuizzes": "Solved Quizzes",
-    "ViewQuizzesForLastViewCourse": "View Quizzes For Last View Course",
+    "ViewQuizzesForLastViewCourse": "Check out the {type} of your last course!",
     "NoQuizFoundForYouToSolve": "No Quiz Found For You To Solve",
     "NoMatchingFoundForYouToSolve": "No Matching Found For You To Solve",
     "BuyAdditionalSubscription": "Buying an additional subscription will extend the subscription duration.",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,6 @@
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 
 export default defineNuxtConfig({
-  devtools: true,
   ssr: false,
   app: {
     head: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,7 @@
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 
 export default defineNuxtConfig({
+  devtools: true,
   ssr: false,
   app: {
     head: {

--- a/pages/challenges/edit-[challenge].vue
+++ b/pages/challenges/edit-[challenge].vue
@@ -22,31 +22,11 @@
   <main
     class="grid-auto gap-card container h-screen-inner min pb-container pt-container grid-rows-[auto_auto_1fr] grid place-items-center"
   >
-    <!-- <p>{{ codingChallenges }}</p> -->
-    <section class="flex gap-3 items-center justify-end mb-3">
-      <article
-        class="text-white font-medium sm:text-xl sm:px-5 pb-1 cursor-pointer border-b-2"
-        :class="
-          selectedTab == 0
-            ? 'border-b-accent'
-            : ' border-black hover:border-tertiary'
-        "
-        @click="selectedTab = 0"
-      >
-        <PencilIcon class="h-5 w-5 text-accent inline-block mr-2" />
-        {{ $t("Headings.Challenge") }}
-      </article>
-      <article
-        class="text-white font-medium sm:text-xl sm:px-5 pb-1 cursor-pointer border-b-2"
-        :class="
-          selectedTab == 1
-            ? 'border-b-accent'
-            : ' border-black hover:border-tertiary'
-        "
-        @click="selectedTab = 1"
-      >
-        {{ $t("Headings.CodingChallenge") }}
-      </article>
+    <section class="flex justify-center">
+      <InputButtonToggle
+        :buttonOptions="buttonOptions"
+        v-model="selectedTab"
+      />
     </section>
 
     <section v-if="selectedTab == 0" class="container-form max-w-4xl">
@@ -109,6 +89,15 @@ export default {
       return route.query.category;
     });
 
+    const buttonOptions = [
+      {
+        name: "Headings.Challenge"
+      },
+      {
+        name: "Headings.CodingChallenge"
+      },
+    ];
+
     onMounted(async () => {
       const [success, error] = await getChallenge(
         categoryId.value,
@@ -132,9 +121,8 @@ export default {
       PencilIcon,
       codingChallenges,
       t,
+      buttonOptions
     };
   },
 };
 </script>
-
-<style scoped></style>

--- a/pages/challenges/leader-board.vue
+++ b/pages/challenges/leader-board.vue
@@ -20,13 +20,19 @@
 -->
 <template>
   <main
-    class="grid-auto gap-card container min pb-container pt-container grid-rows-[auto_auto_1fr]"
+    class="grid-auto gap-card container min pb-container pt-container-sm grid-rows-[auto_auto_1fr]"
   >
-    <InputButtonToggle
-      :buttonOptions="buttonOptions"
-      v-model="selectedbutton"
-    />
-    <p class="text-heading-1 mt-6 mb-12">{{ t("Headings.LeaderBoard") }}:</p>
+    <div class="flex flex-col items-center mb-8">
+      <div class="flex space-x-4 items-center mb-4">
+        <TrophyIcon class="w-8 h-8 text-accent" />
+        <p class="text-heading-1 text-accent">{{ t("Headings.LeaderBoard") }}</p>
+      </div>
+
+      <InputButtonToggle
+        :buttonOptions="buttonOptions"
+        v-model="selectedbutton"
+      />
+    </div>
 
     <SkeletonLeaderboard v-if="loading && selectedbutton != 1" />
 
@@ -48,6 +54,7 @@
 </template>
 
 <script lang="ts">
+import { TrophyIcon } from "@heroicons/vue/24/outline";
 import { useI18n } from "vue-i18n";
 import { useLeaderBoardList } from "~~/composables/leaderboard";
 definePageMeta({
@@ -57,6 +64,9 @@ definePageMeta({
 export default {
   head: {
     title: "Leader board",
+  },
+  components: {
+    TrophyIcon
   },
   setup() {
     const { t } = useI18n();
@@ -91,9 +101,7 @@ export default {
       localStorage.removeItem("selectedButtonLeaderBoard");
     });
 
-    return { buttonOptions, selectedbutton, t, leaderBoardList, loading };
+    return { buttonOptions, selectedbutton, t, leaderBoardList, loading, TrophyIcon };
   },
 };
 </script>
-
-<style scoped></style>

--- a/pages/courses/[id]/index.vue
+++ b/pages/courses/[id]/index.vue
@@ -58,6 +58,7 @@
       </div>
     </section>
     <div
+      v-if="allQuizzes.length !== 0 || matchings.length !== 0"
       class="content-container"
       :class="{
         'hide-scrollbar': !!!allQuizzes || allQuizzes.length <= 1,
@@ -68,28 +69,21 @@
         v-model="selectedbutton"
         class="my-10"
       />
-      <section v-if="allQuizzes && !!allQuizzes.length">
+      <section>
         <article v-show="selectedbutton == 0">
           <h2 class="mb-box text-heading-3">
             {{ t("Headings.QuizzesInCourse") }}
           </h2>
-
-            <QuizList :quizzes="allQuizzes" />
+          <QuizList :quizzes="allQuizzes" />
         </article>
 
         <article v-show="selectedbutton == 1">
           <h2 class="mb-box text-heading-3">
             {{ t("Headings.Matchings") }}
           </h2>
-
-          <div class="content" v-for="(quiz, i) of allQuizzes" :key="i">
-            <MatchingList :quizId="quiz?.id" />
-          </div>
+          <MatchingList :quizId="quiz?.id" />
         </article>
       </section>
-      <h3 v-else class="text-center text-heading-3">
-        {{ t("Headings.NoQuizQuestion") }}
-      </h3>
     </div>
   </main>
 
@@ -114,16 +108,17 @@ export default {
     const course = useCourse();
     const isCourseAccessible = ref(false);
 
-    let buttonOptions: any = [
-      // { name: "Buttons.SeasonalBased" },
-      { name: "Buttons.Quiz" },
-      { name: "Buttons.Matchings" },
-    ];
-    const selectedbutton = ref(0);
-
     const allQuizzes = useQuizzesInCourse();
+    const matchings = useMatchings();
     const route = useRoute();
     const router = useRouter();
+
+    let buttonOptions = computed(() => [
+      { name: "Buttons.Quiz", disabled: allQuizzes.value.length === 0 },
+      { name: "Buttons.Matchings", disabled: matchings.value.length === 0 },
+    ]);
+
+    const selectedbutton = ref(buttonOptions.value.findIndex(option => !option.disabled));
 
     const id = computed(() => {
       return <string>(route.params?.id ?? "");
@@ -177,6 +172,7 @@ export default {
       watchThisLecture,
       skillID,
       allQuizzes,
+      matchings,
       subSkillID,
       buttonOptions,
       selectedbutton,

--- a/pages/courses/[id]/watch.vue
+++ b/pages/courses/[id]/watch.vue
@@ -216,10 +216,10 @@ export default {
 
     const selectedButton = ref(0);
     const buttonOptions = computed(() => [
-      { name: "Buttons.Video" },
-      { name: `${t("Buttons.Quiz")} ${quizzesInLecture.value.length}` },
-      { name: `${t("Buttons.Challenge")} ${codingChallenges.value.length}` },
-      { name: `${t("Buttons.Matching")} ${currentMatches.value.length}` }
+      { name: "Buttons.Video", disabled: false },
+      { name: "Buttons.Quiz", disabled: !quizzesInLecture.value.length },
+      { name: "Buttons.Challenge", disabled: !codingChallenges.value.length },
+      { name: "Buttons.Matching", disabled: !currentMatches.value.length }
     ]);
 
     const activeSection = computed(() => {

--- a/pages/skill-tree/[id]/[skill].vue
+++ b/pages/skill-tree/[id]/[skill].vue
@@ -19,6 +19,11 @@
       :skillID="rootSkillID"
       :activeStepper="activeStepper"
       @activeStepper="activeStepper = $event"
+      :courses="courses"
+      :coachings="coachings"
+      :webinars="webinars"
+      :quizzes="quizzes"
+      :matchings="matchings"
     />
     <div class="h-fit pointer-events-none">
       <SkillTreeNodeSvg
@@ -38,22 +43,21 @@
     <SkillTreeNodeDetailsStepperContent
       class="h-fit"
       :activeStepper="activeStepper"
+      :subSkillID="subSkillID"
+      :skillID="rootSkillID"
       :courses="courses"
       :coachings="coachings"
       :webinars="webinars"
-      :subSkillID="subSkillID"
-      :skillID="rootSkillID"
       :quizzes="quizzes"
+      :matchings="matchings"
     />
   </main>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
-import type { Ref } from "vue";
 import { useI18n } from "vue-i18n";
-import type { Quiz } from "~/types/courseTypes";
 import { getQuizzesInSkill, useQuizzes } from "~~/composables/quizzes";
+
 definePageMeta({
   middleware: ["auth"],
 });
@@ -73,32 +77,20 @@ export default defineComponent({
     const coachings = useCoachings();
     const webinars = useWebinars();
     const quizzes = useQuizzes();
+    const matchings = useMatchings();
     const route = useRoute();
 
-    const rootSkillID = computed(() => {
-      return <string>(route?.params?.id ?? "");
-    });
-
-    const subTreeName = computed(() => {
-      return rootSkillID.value.replace(/_/g, " ");
-    });
-
-    const subSkillID = computed(() => {
-      return <string>(route?.params?.skill ?? "");
-    });
-
-    const skillName = computed(() => {
-      return subSkillID.value.replace(/_/g, " ");
-    });
+    const rootSkillID = computed(() => <string>(route?.params?.id ?? ""));
+    const subTreeName = computed(() => rootSkillID.value.replace(/_/g, " "));
+    const subSkillID = computed(() => <string>(route?.params?.skill ?? ""));
+    const skillName = computed(() => subSkillID.value.replace(/_/g, " "));
 
     const subSkill = computed(() => {
       let skills: any[] = subSkillTree.value?.skills ?? [];
       return skills.find((skill) => skill.id == subSkillID.value);
     });
 
-    const courseIDs = computed(() => {
-      return subSkill.value?.courses ?? [];
-    });
+    const courseIDs = computed(() => subSkill.value?.courses ?? []);
 
     const breadcrumbs = computed(() => {
       return [
@@ -152,14 +144,12 @@ export default defineComponent({
           getCoachingsForThisSubSkill(subSkillID.value),
           getWebinarsForThisSubSkill(subSkillID.value),
           getQuizzesInSkill(subSkillID.value),
+          getMatchingsInSkill(subSkillID.value),
         ]);
-        // assignQuizzes()
       }
 
       loading.value = false;
     });
-
-
 
     onUnmounted(() => {
       if (window) {
@@ -182,9 +172,8 @@ export default defineComponent({
       skillName,
       breadcrumbs,
       quizzes,
+      matchings,
     };
   },
 });
 </script>
-
-<style scoped></style>


### PR DESCRIPTION
# 1. Hide tabs when empty
![image](https://github.com/user-attachments/assets/9f31111a-c1c8-4175-8b60-5f3fb532666d)

# 2. More width for BreadCrums when enough space
![image](https://github.com/user-attachments/assets/8758e813-8e8b-443e-b77f-7c858e754a01)

# 3. Premium banner outside of screen on mobile
![image](https://github.com/user-attachments/assets/9b93e9f5-6106-4a72-90e4-f5e99f188170)

# 4. Replace by "normal" tabs
![image](https://github.com/user-attachments/assets/77ab782e-0beb-40ae-b820-6b707b194ee1)

# 5. QuizQuestions and Matchings not clickable when empty, but Webinars and Coachings
![image](https://github.com/user-attachments/assets/076c4173-0b1d-48b5-bde7-c3d70d17d668)
Solution: Gray out the elements

# 6. Hide overview when empty
![image](https://github.com/user-attachments/assets/c693acfa-23c1-4a5d-b8a5-d5fbf2cf13a7)

# 7. Hide prev button when first lecture
![image](https://github.com/user-attachments/assets/ef8e2ec8-8fcf-41cc-b4bb-e5f66514c60d)

# 8. Add icon
![image](https://github.com/user-attachments/assets/83b84747-184d-410c-aada-17954366a64a)

# 9. Center tabs and redesign headline
![image](https://github.com/user-attachments/assets/f95ea1f6-950a-424c-983d-ddf95bf5fe88)

# 10. Center elements
![image](https://github.com/user-attachments/assets/7a6b7aa1-7cc8-42f0-9381-59a6f9c6d3a3)

# 11. Hide when empty and correct error message
https://github.com/user-attachments/assets/fe49e587-946d-4e9b-8738-04c6f3a58664

