### PR TITLE
Issue#117: Sorting of self hosted courses

### DIFF
--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -20,8 +20,6 @@
       controlsList="nodownload"
       oncontextmenu="return false;"
       :key="`video-${videoSRC}`"
-      @timeupdate="onTimeUpdate(activeLecture.id,$event)"
-      @loadstart="setTime(activeLecture.id,$event)"
     >      
       <track kind="captions" />
       <source ref="refSource" :src="videoSRC" type="video/mp4" />
@@ -82,28 +80,7 @@ export default defineComponent({
     );
 
 
-    function onTimeUpdate(videoID: any,event:any) {
-      const currentTime = event.target.currentTime;
-      const currentvideotime: any = useCookie("currentvideotime");
-      currentvideotime.value = currentTime;
-      const currentvideo: any = useCookie("currentvideo");
-      if ( currentTime < 1){
-        currentvideo.value = videoID;
-      }
-    }
-
-    function setTime(videoID: any,event:any){
-      const currentvideo: any = useCookie("currentvideo");
-      const currentvideotime: any = useCookie("currentvideotime");
-      if (currentvideo.value === videoID){
-        event.target.currentTime = currentvideotime?.value;
-      }
-      else{
-        currentvideotime.removeItem
-        currentvideo.removeItem
-      }
-    }
-    return { videoSRC, refSource, onTimeUpdate, setTime };
+    return { videoSRC, refSource };
   },
 });
 </script>

--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -75,7 +75,7 @@ export default defineComponent({
             await getLectureVideoSRC(courseID, newValue);
             // refSource.value.setAttribute('src', videoSRC.value);
             refSource.value.src = videoSRC.value;
-          }, 40000);
+          }, 4000000);
         }
       },
       { deep: true, immediate: true }

--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -20,7 +20,9 @@
       controlsList="nodownload"
       oncontextmenu="return false;"
       :key="`video-${activeLecture.id}`"
-    >
+      @timeupdate="onTimeUpdate(activeLecture.id,$event)"
+      @loadstart="setTime(activeLecture.id,$event)"
+    >      
       <track kind="captions" />
       <source ref="refSource" :src="videoSRC" type="video/mp4" />
       <p class="vjs-no-js">
@@ -79,7 +81,29 @@ export default defineComponent({
       { deep: true, immediate: true }
     );
 
-    return { videoSRC, refSource };
+
+    function onTimeUpdate(videoID: any,event:any) {
+      const currentTime = event.target.currentTime;
+      const currentvideotime: any = useCookie("currentvideotime");
+      currentvideotime.value = currentTime;
+      const currentvideo: any = useCookie("currentvideo");
+      if ( currentTime < 1){
+        currentvideo.value = videoID;
+      }
+    }
+
+    function setTime(videoID: any,event:any){
+      const currentvideo: any = useCookie("currentvideo");
+      const currentvideotime: any = useCookie("currentvideotime");
+      if (currentvideo.value === videoID){
+        event.target.currentTime = currentvideotime?.value;
+      }
+      else{
+        currentvideotime.removeItem
+        currentvideo.removeItem
+      }
+    }
+    return { videoSRC, refSource, onTimeUpdate, setTime };
   },
 });
 </script>

--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -19,7 +19,7 @@
       allowfullscreen
       controlsList="nodownload"
       oncontextmenu="return false;"
-      :key="`video-${activeLecture.id}`"
+      :key="`video-${videoSRC}`"
       @timeupdate="onTimeUpdate(activeLecture.id,$event)"
       @loadstart="setTime(activeLecture.id,$event)"
     >      

--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -73,7 +73,7 @@ export default defineComponent({
             await getLectureVideoSRC(courseID, newValue);
             // refSource.value.setAttribute('src', videoSRC.value);
             refSource.value.src = videoSRC.value;
-          }, 4000000);
+          }, 28800); //8 hours
         }
       },
       { deep: true, immediate: true }

--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -11,6 +11,7 @@
     ></iframe>
 
     <video
+      ref="video"
       v-else-if="activeLecture.type == 'mp4'"
       :poster="course.image"
       controls
@@ -20,7 +21,7 @@
       controlsList="nodownload"
       oncontextmenu="return false;"
       :key="`video-${videoSRC}`"
-    >      
+    >
       <track kind="captions" />
       <source ref="refSource" :src="videoSRC" type="video/mp4" />
       <p class="vjs-no-js">
@@ -53,6 +54,7 @@ export default defineComponent({
 
     let videoInterval: any;
     const refSource = ref<HTMLSourceElement | any>(null);
+    const video = ref<HTMLVideoElement | null>(null); 
 
     watch(
       () => props.activeLecture,
@@ -71,6 +73,12 @@ export default defineComponent({
           refSource.value.setAttribute("src", videoSRC.value);
           videoInterval = setInterval(async () => {
             await getLectureVideoSRC(courseID, newValue);
+            if (video.value) {
+              video.value.pause();
+              refSource.value.src = videoSRC.value;
+              video.value.load();
+              video.value.play();
+            };
             // refSource.value.setAttribute('src', videoSRC.value);
             refSource.value.src = videoSRC.value;
           },  28800000); //8 hours
@@ -80,7 +88,7 @@ export default defineComponent({
     );
 
 
-    return { videoSRC, refSource };
+    return { videoSRC, refSource, video };
   },
 });
 </script>

--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -73,7 +73,7 @@ export default defineComponent({
             await getLectureVideoSRC(courseID, newValue);
             // refSource.value.setAttribute('src', videoSRC.value);
             refSource.value.src = videoSRC.value;
-          }, 28800); //8 hours
+          },  28800000); //8 hours
         }
       },
       { deep: true, immediate: true }


### PR DESCRIPTION
## Description<!-- Please provide a summary of the change and include relevant motivation and context. -->
The Problem was that the video is rendered before the source of the video changed and the change of the video source didn't lead to a re-render of the video.

Changed key attribute of the video from "activelecture.id" to "videoSRC", so the video is re-rendered every time the video source changes.

In addition, the time span when a new video source is created was extended from 40 Seconds to 4000 Seconds so the Video is not re rendered every 40 Seconds.

I don't know if this will cause problems with the API because I don't know when the video source links expire.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Translation updates (fix/improve or add new translations)

<!-- Replace ISSUE-NUMBER with the id of the ticket this PR is supposed to solve -->
Fixes Bootstrap-Academy/Bootstrap-Academy#117

<!-- To receive a reward for contributing, enter the username of your Bootstrap Academy account -->
My Bootstrap Academy username: R4bbit