### PR TITLE
fix: Implement ARIA Roles & Properties #144

### DIFF
--- a/components/CookiePolicy.vue
+++ b/components/CookiePolicy.vue
@@ -1,9 +1,15 @@
 <template>
 	<div>
 		<Modal v-if="!agreed && route.name != 'docs-privacy'">
-			<Dialog :dialog="dialog">
+			<Dialog
+				:dialog="dialog"
+				role="dialog"
+				aria-labelledby="cookie-dialog-title"
+				aria-describedby="cookie-dialog-description"
+				aria-modal="true"
+			>
 				<template #content="{ t }">
-					<p class="text-body-1 text-body font-body m-0 mt-box">
+					<p id="cookie-dialog-description" class="text-body-1 text-body font-body m-0 mt-box">
 						{{ t('Body.CookiePolicy') }}
 
 						<NuxtLink
@@ -20,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, onMounted } from 'vue';
 import Gleap from 'gleap';
 
 export default defineComponent({
@@ -62,6 +68,14 @@ export default defineComponent({
       set(data: boolean) {
         cookie_agreedToCookiePolicy.value = data;
       },
+    });
+
+    onMounted(() => {
+      const dialogElement = document.querySelector('[role="dialog"]');
+      if (dialogElement && dialogElement instanceof HTMLElement) {
+        dialogElement.setAttribute('tabindex', '-1');
+        dialogElement.focus();
+      }
     });
 
     return { agreed, dialog, route };


### PR DESCRIPTION
Pull Request: Improve Accessibility for Cookie Dialog

Summary of Changes
	•	Implemented ARIA roles to enhance semantic accessibility of the cookie dialog.
	•	Added focus management to ensure initial focus jumps directly to the cookie dialog when displayed.

Testing
	•	Browser Testing:
	•	Successfully tested on Chrome and Edge.
	•	Attempted testing on Safari, but the app failed to render.
	•	Screen Reader Testing:
	•	Tested with VoiceOver on macOS.

Known Issues
	•	Users can navigate out of modals using the Tab key. This is a broader issue affecting all modals, unrelated to this specific PR.
	•	Limited ability to verify the accessibility of other dialogs due to lack of visual feedback. Suggesting collaboration, such as pair programming, to identify and address further accessibility gaps.

Related Issue
	•	https://github.com/Bootstrap-Academy/Bootstrap-Academy/issues/144