### PR TITLE
Issue#158 Added info tooltip for Singel- and Multiple-Choice questions

### DIFF
--- a/components/quiz/Card.vue
+++ b/components/quiz/Card.vue
@@ -20,11 +20,12 @@
     </h3>
 
     <div class="flex justify-between gap-box items-center">
-      <p class="text-body-2" v-if="data?.single_choice">
-        {{ t("Headings.SingleChoice") }}
+      <p class="text-body-2">
+        {{ data?.single_choice ? t("Headings.SingleChoice") : t("Headings.MultiChoice") }}
       </p>
-      <p class="text-body-2" v-else>{{ t("Headings.MultiChoice") }}</p>
+      <span class="info-icon" :title="`Diese Frage erlaubt ${data?.single_choice ? 'nur eine Antwort' : 'mehrere Antworten'}.`">ℹ️</span>
     </div>
+
   </article>
 </template>
 


### PR DESCRIPTION

## Description
Adds a ℹ️ icon with an explanation for single/multiple choice questions. If you hover over the icon you will see whether only one or more answers are allowed for this quiz or not

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Translation updates (fix/improve or add new translations)

Fixes Bootstrap-Academy/Bootstrap-Academy#ISSUE-158

My Bootstrap Academy username: kayra
