### PR TITLE
Fix user logout during video sessions and chapter completion

### DIFF
--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -98,6 +98,9 @@ export default defineComponent({
       timeCookie.value = currentVideoTime;
     
       if (currentVideoTime < 1) videoCookie.value = videoID;
+
+      const lastActivity = useCookie("lastVideoActivity");
+      lastActivity.value = Date.now();
     }
     
     function onVideoLoad(videoID: string, event: any) {

--- a/components/course/VideoControls.vue
+++ b/components/course/VideoControls.vue
@@ -110,6 +110,7 @@ async function goToPrevLecture() {
 }
 
 async function goToNextLecture() {
+  const { ensureTokenFresh } = await import('~/composables/tokenManager');
   if (lectures.value.length <= 0) return;
 
   let indexOfCurrentLecture = lectures.value.findIndex(
@@ -118,6 +119,9 @@ async function goToNextLecture() {
 
   // current lecture is last lecture
   if (indexOfCurrentLecture >= lectures.value.length - 1) {
+    // Ensure token is fresh before showing completion dialog
+    await ensureTokenFresh();
+    
     openDialog(
       "success",
       "Headings.CourseCompleted",
@@ -139,6 +143,13 @@ async function goToNextLecture() {
   // current lecture was not found
   else if (indexOfCurrentLecture < 0) {
     // handle error
+    return;
+  }
+
+  // Ensure token is fresh before navigating to next lecture
+  const tokenIsValid = await ensureTokenFresh();
+  if (!tokenIsValid) {
+    openSnackbar("error", "Session expired. Please login again.");
     return;
   }
 

--- a/composables/fetch.js
+++ b/composables/fetch.js
@@ -216,7 +216,12 @@ function isAccessTokenExpired() {
     let exp = jwtDecode(accessToken).exp;
     let time = parseInt(Math.round(new Date().getTime() / 1000));
     let difference = exp - time;
-    let isTokenExpired = difference <= 100 ? true : false;
+
+    const lastActivity = useCookie("lastVideoActivity");
+    const isWatchingVideo = lastActivity.value && (Date.now() - lastActivity.value) < 120000; // Active within last 2 minutes
+    
+    const threshold = isWatchingVideo ? 30 : 100;
+    let isTokenExpired = difference <= threshold ? true : false;
 
     return isTokenExpired;
   } catch (error) {

--- a/composables/tokenManager.ts
+++ b/composables/tokenManager.ts
@@ -1,0 +1,122 @@
+import { jwtDecode } from "jwt-decode";
+
+// Token refresh service for maintaining user sessions during long activities
+export class TokenManager {
+  private static instance: TokenManager;
+  private refreshInterval: NodeJS.Timeout | null = null;
+  private isActive = false;
+  private readonly REFRESH_THRESHOLD = 300;
+  private readonly CHECK_INTERVAL = 60000;
+
+  private constructor() {}
+
+  public static getInstance(): TokenManager {
+    if (!TokenManager.instance) {
+      TokenManager.instance = new TokenManager();
+    }
+    return TokenManager.instance;
+  }
+
+  /**
+   * Start monitoring and proactively refresh tokens
+   * Should be called when user starts activities that might take long time (video watching, course completion)
+   */
+  public startMonitoring(): void {
+    if (this.isActive) return;
+    
+    this.isActive = true;
+    this.refreshInterval = setInterval(() => {
+      this.checkAndRefreshToken();
+    }, this.CHECK_INTERVAL);
+    
+    // Immediate check
+    this.checkAndRefreshToken();
+  }
+
+  /**
+   * Stop monitoring
+   * Should be called when user leaves video/course pages
+   */
+  public stopMonitoring(): void {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+      this.refreshInterval = null;
+    }
+    this.isActive = false;
+  }
+
+  /**
+   * Check if token needs refresh and refresh it if necessary
+   */
+  private async checkAndRefreshToken(): Promise<void> {
+    try {
+      const accessToken = getAccessToken();
+      
+      if (!accessToken) {
+        this.stopMonitoring();
+        return;
+      }
+
+      const decoded = jwtDecode(accessToken);
+      const currentTime = Math.floor(Date.now() / 1000);
+      const timeUntilExpiry = (decoded.exp || 0) - currentTime;
+
+      // If token expires within the threshold, refresh it
+      if (timeUntilExpiry <= this.REFRESH_THRESHOLD) {
+        console.log('Proactively refreshing token before expiry');
+        const { refresh } = await import('./auth');
+        const [success, error] = await refresh();
+        
+        if (!success) {
+          console.warn('Failed to refresh token:', error);
+          this.stopMonitoring();
+        }
+      }
+    } catch (error) {
+      console.warn('Token monitoring error:', error);
+    }
+  }
+
+  /**
+   * Manual refresh trigger for critical actions
+   */
+  public async ensureTokenFresh(): Promise<boolean> {
+    try {
+      const accessToken = getAccessToken();
+      
+      if (!accessToken) {
+        return false;
+      }
+
+      const decoded = jwtDecode(accessToken);
+      const currentTime = Math.floor(Date.now() / 1000);
+      const timeUntilExpiry = (decoded.exp || 0) - currentTime;
+
+      // Refresh if token expires within 2 minutes
+      if (timeUntilExpiry <= 120) {
+        const { refresh } = await import('./auth');
+        const [success, error] = await refresh();
+        return !!success;
+      }
+      
+      return true;
+    } catch (error) {
+      console.warn('Token refresh error:', error);
+      return false;
+    }
+  }
+}
+
+export const tokenManager = TokenManager.getInstance();
+
+export function startTokenMonitoring(): void {
+  tokenManager.startMonitoring();
+}
+
+export function stopTokenMonitoring(): void {
+  tokenManager.stopMonitoring();
+}
+
+export async function ensureTokenFresh(): Promise<boolean> {
+  return tokenManager.ensureTokenFresh();
+}

--- a/pages/courses/[id]/watch.vue
+++ b/pages/courses/[id]/watch.vue
@@ -302,11 +302,20 @@ export default {
       }
       await Promise.all([getCourseByID(courseID), watchCourse(courseID)]);
 
+      // Start token monitoring for video sessions to prevent logout
+      const { startTokenMonitoring } = await import('~/composables/tokenManager');
+      startTokenMonitoring();
+
       loading.value = false;
     });
 
     onBeforeUnmount(() => {
       localStorage.removeItem("selectedButton");
+      
+      // Stop token monitoring when leaving the page
+      import('~/composables/tokenManager').then(({ stopTokenMonitoring }) => {
+        stopTokenMonitoring();
+      });
     });
 
 


### PR DESCRIPTION
## Problem
> **User description of the error**: ‘The website keeps logging me out of the video page after a short time. Whenever I finish a chapter in the course and mark it as “done”, it kicks me out.’

Users were experiencing frequent logouts when watching course videos and completing chapters. The issue occurred because:

1. JWT access tokens have short expiration times
2. During video watching, no API calls are made, causing tokens to expire silently
3. When users complete chapters and mark them as done, the expired token triggers automatic logout

## Solution

### TokenManager Service
- Monitors token expiration every minute in the background
- Automatically refreshes tokens when they have 5 minutes remaining

### Activity-Aware Token Management
- Tracks video watching activity via `timeupdate` events
- Ensures token freshness before critical actions like chapter completion
- Automatically starts monitoring when users enter course watch pages, stops monitoring when leaving
