### PR TITLE
Improve skill tree pan and zoom

### DIFF
--- a/components/skill-tree/Header.vue
+++ b/components/skill-tree/Header.vue
@@ -1,7 +1,11 @@
 <template>
   <header
-    class="flex gap-card items-center justify-between flex-wrap capitalize"
-    :class="{ 'absolute left-0 top-card w-screen container-fluid': absolute }"
+    class="flex gap-card items-center justify-between flex-wrap capitalize pointer-events-auto z-20"
+    :class="
+      absolute
+        ? 'absolute left-0 top-card w-screen container-fluid'
+        : 'relative'
+    "
   >
     <div class="py-2 px-4 md:py-3 md:px-6 bg-secondary style-box">
       <template v-for="(path, i) of breadcrumbs" :key="i">
@@ -29,10 +33,6 @@
       </Btn>
     </NuxtLink>
 
-    <SkillTreeZoomLevel
-      v-if="!noZoomLevel"
-      @zoomLevel="emit('zoomLevel', $event)"
-    />
   </header>
 </template>
 
@@ -48,8 +48,7 @@ export default defineComponent({
     absolute: { type: Boolean, default: true },
     quizzesQuickStart: { type: Boolean, default: false },
   },
-  emits: ["zoomLevel"],
-  setup(props, { emit }) {
+  setup() {
     const { t } = useI18n();
     const lastViewCourse: any = useCookie("lastViewCourse");
 
@@ -65,7 +64,7 @@ export default defineComponent({
       }
     });
 
-    return { emit, t, lastViewCourse, lastViewCourseInfo };
+    return { t, lastViewCourse, lastViewCourseInfo };
   },
 });
 </script>

--- a/components/skill-tree/Node.vue
+++ b/components/skill-tree/Node.vue
@@ -6,18 +6,14 @@
       :flameEffect="(viewSubtree ? root_skill_level_value : sub_skill_level_value) > 50"
       :isBookmarked="isNodeBookmarked" @bookmarked="toggleBookmark" />
 
-    <foreignObject v-if="zoomLevel != 1 && isFilled" x="0" :y="nodeSize - 10" :width="nodeSize"
+    <foreignObject v-if="isFilled" x="0" :y="nodeSize - 10" :width="nodeSize"
       :height="active || completed ? 200 : 100">
       <h6
-        class="origin-center select-none transition-all duration-500 ease-in-out text-center w-full h-auto pointer-events-none capitalize"
+        class="origin-center select-none transition-all duration-500 ease-in-out text-center w-full h-auto pointer-events-none capitalize text-body-2"
         :class="{
           'pt-6': active,
           'pt-7': completed,
           'pt-2': !active && !completed,
-          'text-heading-3': zoomLevel == 5,
-          'text-heading-4': zoomLevel == 4,
-          'text-heading-5': zoomLevel == 3,
-          'text-body-2': zoomLevel == 2,
         }" v-if="node && node.name != 'start'">
         {{ node?.name ?? '' }}
       </h6>
@@ -37,7 +33,6 @@ export default defineComponent({
     selectedNode: { default: null },
     row: { type: Number, default: 0 },
     column: { type: Number, default: 0 },
-    zoomLevel: { type: Number, default: 2 },
     viewSubtree: { type: Boolean, default: false },
     viewSkill: { type: Boolean, default: false },
     xp: { type: Object as PropType<any>, default: null },
@@ -61,20 +56,8 @@ export default defineComponent({
     const user = useUser();
 
 
-    const size = computed(() => {
-      switch (props.zoomLevel) {
-      case 5:
-        return 125;
-      case 4:
-        return 100;
-      case 3:
-        return 75;
-      case 2:
-        return 50;
-      default:
-        return 25;
-      }
-    });
+    const DEFAULT_NODE_SIZE = 50;
+    const size = computed(() => DEFAULT_NODE_SIZE);
 
     const nodeSize = computed(() => {
       emit('size', size.value * occupiedSpace);

--- a/components/skill-tree/Pathway.vue
+++ b/components/skill-tree/Pathway.vue
@@ -37,41 +37,17 @@ import { defineComponent } from 'vue';
 export default defineComponent({
   props: {
     pathway: { type: String, default: '' },
-    zoomLevel: { default: 2 },
   },
   setup(props) {
     const triangle = reactive({
       markerWidth: 3,
       markerHeight: 3,
-      refX: -7,
+      refX: -10,
       refY: 1.5,
       points: '3 0, 3 3, 0 1.5',
     });
 
-    const strokeWidth = computed(() => {
-      switch (props.zoomLevel) {
-      case 5:
-        triangle.refY = 1.5;
-        triangle.refX = -25;
-        return 10;
-      case 4:
-        triangle.refY = 1.5;
-        triangle.refX = -20;
-        return 8;
-      case 3:
-        triangle.refY = 1.5;
-        triangle.refX = -15;
-        return 8;
-      case 2:
-        triangle.refY = 1.5;
-        triangle.refX = -10;
-        return 8;
-      default:
-        triangle.refY = 1.5;
-        triangle.refX = -3.5;
-        return 8;
-      }
-    });
+    const strokeWidth = 8;
 
     return { triangle, strokeWidth };
   },

--- a/composables/skilltree.ts
+++ b/composables/skilltree.ts
@@ -85,7 +85,6 @@ export function scrollMapToNode(
   map: any,
   mapRef: any,
   nodeSize: number,
-  zoomLevel: number,
   row: number,
   column: number,
   smooth: boolean,
@@ -98,18 +97,7 @@ export function scrollMapToNode(
   if (!!!ref) return;
   if (!mapRef) return;
 
-  let shiftBy;
-  if (zoomLevel == 5) {
-    shiftBy = nodeSize * 0.5;
-  } else if (zoomLevel == 4) {
-    shiftBy = nodeSize * 0.5;
-  } else if (zoomLevel == 3) {
-    shiftBy = nodeSize * 0.5;
-  } else if (zoomLevel == 2) {
-    shiftBy = nodeSize * 0.5;
-  } else {
-    shiftBy = nodeSize * 0.5;
-  }
+  const shiftBy = nodeSize * 0.5;
 
   let cx = parseInt(ref.getAttribute("x") ?? 0) + shiftBy;
   let cy = parseInt(ref.getAttribute("y") ?? 0) + shiftBy;

--- a/composables/skilltree.ts
+++ b/composables/skilltree.ts
@@ -1,4 +1,5 @@
 import { ref } from "vue";
+import type { PanzoomObject } from "@panzoom/panzoom";
 import { SkillTree, RootSkill, SubSkill } from "~/types/skillTreeTypes";
 
 export const useSubSkillTree = () =>
@@ -87,13 +88,15 @@ export function scrollMapToNode(
   zoomLevel: number,
   row: number,
   column: number,
-  smooth: boolean
+  smooth: boolean,
+  panzoomInstance?: PanzoomObject
 ) {
   if (!!!map[row] || !!!map[row][column]) return;
 
   let ref = map[row][column];
 
   if (!!!ref) return;
+  if (!mapRef) return;
 
   let shiftBy;
   if (zoomLevel == 5) {
@@ -115,7 +118,22 @@ export function scrollMapToNode(
   let centerTop = cy - screenCenterTop;
   let centerLeft = cx - screenCenterLeft;
 
-  mapRef.scroll({
+  if (panzoomInstance && mapRef) {
+    const rect =
+      typeof mapRef.getBoundingClientRect === "function"
+        ? mapRef.getBoundingClientRect()
+        : null;
+
+    if (rect) {
+      const { scale } = panzoomInstance.getTransform();
+      const targetX = rect.width * 0.5 - cx * scale;
+      const targetY = rect.height * 0.5 - cy * scale;
+      panzoomInstance.pan(targetX, targetY, { animate: smooth });
+      return;
+    }
+  }
+
+  mapRef?.scroll?.({
     top: centerTop,
     left: centerLeft,
     behavior: smooth ? "smooth" : "auto",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@floating-ui/dom": "^1.7.4",
         "@headlessui/vue": "^1.7.23",
         "@heroicons/vue": "^2.2.0",
+        "@panzoom/panzoom": "^4.5.1",
         "@typescript-eslint/parser": "^8.46.2",
         "@vueuse/core": "^14.0.0",
         "async-mutex": "^0.5.0",
@@ -2721,6 +2722,12 @@
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
+    },
+    "node_modules/@panzoom/panzoom": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@panzoom/panzoom/-/panzoom-4.6.0.tgz",
+      "integrity": "sha512-3KxkY1lNKFn98fW5ZFR6vV0YzsXj3I4EQDyFWSXME6/cic86eSS7VjuqIjrA3PEpySo0r5fFtlX8eYCt4JPUFQ==",
+      "license": "MIT"
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "npm": "^11.6.2",
     "qrcode.vue": "^3.6.0",
     "vue-recaptcha-v3": "^2.0.1",
-    "vuedraggable": "^4.1.0"
+    "vuedraggable": "^4.1.0",
+    "@panzoom/panzoom": "^4.5.1"
   }
 }

--- a/pages/skill-tree/[id]/index.vue
+++ b/pages/skill-tree/[id]/index.vue
@@ -21,7 +21,6 @@
             v-for="(pathway, p) of pathways"
             :key="p"
             :pathway="pathway.path"
-            :zoomLevel="zoomLevel"
             @click="scrollViaPathway(pathway.node, pathway.parent)"
           />
         </g>
@@ -38,7 +37,6 @@
               :column="j"
               @ref="insertRefInMap($event, i, j)"
               :node="getNode(i, j)"
-              :zoomLevel="zoomLevel"
               @size="nodeSize = $event"
               @click="scrollToNode(i, j, true)"
               @move="setSelectedNode($event)"
@@ -251,7 +249,6 @@ export default {
         map,
         mainRef.value,
         nodeSize.value,
-        zoomLevel.value,
         row,
         column,
         smooth,
@@ -343,8 +340,6 @@ export default {
     }
 
     // ! ======================================================= Controls
-    const zoomLevel = ref(2);
-
     const handleWheel = (event: WheelEvent) => {
       event.preventDefault();
       const instance = panzoomInstance.value;
@@ -444,7 +439,6 @@ export default {
       pathways,
       scrollViaPathway,
 
-      zoomLevel,
       t,
       subTreeName,
       breadcrumbs,

--- a/pages/skill-tree/[id]/index.vue
+++ b/pages/skill-tree/[id]/index.vue
@@ -4,10 +4,7 @@
       <Title>Sub Skill Tree - {{ subTreeName }}</Title>
     </Head>
 
-    <SkillTreeHeader
-      @zoomLevel="zoomLevel = $event"
-      :breadcrumbs="breadcrumbs"
-    />
+    <SkillTreeHeader :breadcrumbs="breadcrumbs" />
 
     <LoadingDots v-if="loading">
       {{ t("Body.SubSkillTreeLoading", { placeholder: subTreeName }) }}
@@ -15,12 +12,10 @@
 
     <section
       v-else-if="nodes && nodes.length"
-      class="map w-screen h-fit m-auto max-w-[100vw] h-screen-main overflow-auto"
+      class="map relative z-0 w-screen h-fit m-auto max-w-[100vw] h-screen-main overflow-hidden"
       ref="mainRef"
-      @mousedown="startDrag"
-      :class="{ 'cursor-grabbing': isDragging }"
     >
-      <svg :width="mapWidth" :height="mapHeight" :viewBox="mapViewBox">
+      <svg ref="svgRef" :width="mapWidth" :height="mapHeight" :viewBox="mapViewBox">
         <g v-if="setupComplete && selectedNode.id == ''">
           <SkillTreePathway
             v-for="(pathway, p) of pathways"
@@ -72,6 +67,8 @@
 
 <script lang="ts">
 import { useI18n } from "vue-i18n";
+import type { Ref } from "vue";
+import Panzoom, { type PanzoomObject } from "@panzoom/panzoom";
 import { useSubSkillTree, getSubSkillTree, createPathwaysForTree } from "~/composables/skilltree";
 
 export default {
@@ -100,6 +97,15 @@ export default {
     });
 
     const { t } = useI18n();
+
+    const MAX_SCALE = 3;
+    const MIN_SCALE = 0.4;
+    const ZOOM_BASE_STEP = 0.06;
+    const MIN_WHEEL_STEP = 0.015;
+    const MAX_WHEEL_STEP = 0.35;
+
+    const clamp = (value: number, min: number, max: number) =>
+      Math.min(Math.max(value, min), max);
 
     // ! ======================================================= Set Up
     const setupComplete = ref(false);
@@ -134,6 +140,9 @@ export default {
     };
 
     const nodeSize = ref(0);
+    const svgRef = ref<SVGSVGElement | null>(null);
+    const panzoomInstance = ref<PanzoomObject | null>(null);
+    const pendingTarget = ref<{ row: number; column: number } | null>(null);
 
     let selectedNode = reactive(getInitialNode());
     const router = useRouter();
@@ -232,7 +241,11 @@ export default {
     }
 
     function scrollToNode(row: number, column: number, smooth: boolean) {
-      nextNode.value = { row: row, column: column };
+      nextNode.value = { row, column };
+
+      if (!panzoomInstance.value) {
+        pendingTarget.value = { row, column };
+      }
 
       scrollMapToNode(
         map,
@@ -241,7 +254,8 @@ export default {
         zoomLevel.value,
         row,
         column,
-        smooth
+        smooth,
+        panzoomInstance.value ?? undefined
       );
     }
 
@@ -329,26 +343,47 @@ export default {
     }
 
     // ! ======================================================= Controls
-    const zoomLevel = ref(-1);
+    const zoomLevel = ref(2);
 
-    watch(
-      () => zoomLevel.value,
-      (newValue, oldValue) => {
-        if (newValue != oldValue) {
-          setupComplete.value = false;
-        }
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const instance = panzoomInstance.value;
+      if (!instance) return;
 
-        nextTick(() => {
-          createPathways();
+      const delta =
+        event.deltaY === 0 && event.deltaX ? event.deltaX : event.deltaY;
+      if (!delta) return;
 
-          let row = nextNode.value.row;
-          let column = nextNode.value.column;
+      const intensity = clamp(Math.abs(delta) / 120, 0.2, 4);
+      const step = clamp(
+        intensity * ZOOM_BASE_STEP,
+        MIN_WHEEL_STEP,
+        MAX_WHEEL_STEP
+      );
 
-          scrollToNode(row, column, false);
-          setupComplete.value = true;
-        });
+      instance.zoomWithWheel(event, { step, animate: false });
+    };
+
+    function initializePanzoom() {
+      if (!svgRef.value || !mainRef.value || panzoomInstance.value) return;
+
+      const instance = Panzoom(svgRef.value, {
+        maxScale: MAX_SCALE,
+        minScale: MIN_SCALE,
+        step: 0.1,
+        cursor: "grab",
+      });
+
+      panzoomInstance.value = instance;
+      mainRef.value.addEventListener("wheel", handleWheel, { passive: false });
+      mainRef.value.style.touchAction = "none";
+
+      if (pendingTarget.value) {
+        const { row, column } = pendingTarget.value;
+        pendingTarget.value = null;
+        nextTick(() => scrollToNode(row, column, false));
       }
-    );
+    }
 
     watch(
       () => map,
@@ -368,49 +403,22 @@ export default {
       { immediate: true, deep: true }
     );
 
-    // ! ======================================================= Dragging
-    const isDragging = ref(false);
-    const startX = ref(0);
-    const startY = ref(0);
-    const scrollLeft = ref(0);
-    const scrollTop = ref(0);
-
-    const startDrag = (event: MouseEvent) => {
-      if (event.button !== 0) return;
-
-      const target = event.target as HTMLElement;
-      if (target.tagName === "foreignObject" || target.tagName === "path") return;
-
-      isDragging.value = true;
-      startX.value = event.pageX - mainRef.value!.offsetLeft;
-      startY.value = event.pageY - mainRef.value!.offsetTop;
-      scrollLeft.value = mainRef.value!.scrollLeft;
-      scrollTop.value = mainRef.value!.scrollTop;
-      document.addEventListener("mousemove", drag);
-      document.addEventListener("mouseup", stopDrag);
-    };
-
-    const drag = (event: MouseEvent) => {
-      if (!isDragging.value) return;
-      event.preventDefault();
-      const x = event.pageX - mainRef.value!.offsetLeft;
-      const y = event.pageY - mainRef.value!.offsetTop;
-      const walkX = x - startX.value;
-      const walkY = y - startY.value;
-
-      mainRef.value!.scrollLeft = scrollLeft.value - walkX;
-      mainRef.value!.scrollTop = scrollTop.value - walkY;
-
-      if (event.clientX <= 0 || event.clientX >= window.innerWidth || event.clientY <= 0 || event.clientY >= window.innerHeight) {
-        stopDrag();
+    watch(
+      () => setupComplete.value,
+      (complete) => {
+        if (complete) {
+          nextTick(() => initializePanzoom());
+        }
       }
-    };
+    );
 
-    const stopDrag = () => {
-      isDragging.value = false;
-      document.removeEventListener("mousemove", drag);
-      document.removeEventListener("mouseup", stopDrag);
-    };
+    onUnmounted(() => {
+      if (mainRef.value) {
+        mainRef.value.removeEventListener("wheel", handleWheel);
+      }
+      panzoomInstance.value?.destroy();
+      panzoomInstance.value = null;
+    });
 
     return {
       setupComplete,
@@ -440,10 +448,7 @@ export default {
       t,
       subTreeName,
       breadcrumbs,
-
-      isDragging,
-      startDrag,
-      
+      svgRef,
       xp,
     };
   },

--- a/pages/skill-tree/index.vue
+++ b/pages/skill-tree/index.vue
@@ -1,10 +1,6 @@
 <template>
   <main class="relative h-screen-main min grid place-items-center select-none">
-    <SkillTreeHeader
-      @zoomLevel="zoomLevel = $event"
-      :breadcrumbs="breadcrumbs"
-      :quizzesQuickStart="true"
-    />
+    <SkillTreeHeader :breadcrumbs="breadcrumbs" :quizzesQuickStart="true" />
 
     <LoadingDots v-if="loading">
       {{ t("Body.RootSkillTreeLoading") }}
@@ -12,13 +8,10 @@
 
     <section
       v-else-if="nodes && nodes.length"
-      class="map w-screen h-fit m-auto max-w-[100vw] h-screen-main max overflow-scroll"
+      class="map relative z-0 w-screen h-fit m-auto max-w-[100vw] h-screen-main max overflow-hidden"
       ref="mainRef"
-      @wheel="handleWheelZoom"
-      @mousedown="startDrag"
-      :class="{ 'cursor-grabbing': isDragging }"
     >
-      <svg :width="mapWidth" :height="mapHeight" :viewBox="mapViewBox">
+      <svg ref="svgRef" :width="mapWidth" :height="mapHeight" :viewBox="mapViewBox">
         <g v-if="setupComplete">
           <SkillTreePathway v-for="(pathway, p) of pathways" :key="p" :pathway="pathway.path" :zoomLevel="zoomLevel"
             @click="scrollViaPathway(pathway.node, pathway.parent)" />
@@ -40,6 +33,7 @@
 import { useI18n } from "vue-i18n";
 import { PlusCircleIcon, ArrowUpTrayIcon } from "@heroicons/vue/24/solid";
 import type { Ref } from "vue";
+import Panzoom, { type PanzoomObject } from "@panzoom/panzoom";
 
 export default {
   head: {
@@ -57,6 +51,15 @@ export default {
     const { t } = useI18n();
     const user = useUser();
     const xp = useXP();
+
+    const MAX_SCALE = 3;
+    const MIN_SCALE = 0.4;
+    const ZOOM_BASE_STEP = 0.06;
+    const MIN_WHEEL_STEP = 0.015;
+    const MAX_WHEEL_STEP = 0.35;
+
+    const clamp = (value: number, min: number, max: number) =>
+      Math.min(Math.max(value, min), max);
 
     // ! ======================================================= Set Up
     function onclickUploadCertificates() {
@@ -92,6 +95,9 @@ export default {
 
     const nodes: any[] = reactive([]);
     const nodeSize = ref(0);
+    const svgRef = ref<SVGSVGElement | null>(null);
+    const panzoomInstance = ref<PanzoomObject | null>(null);
+    const pendingTarget = ref<{ row: number; column: number } | null>(null);
 
     onMounted(async () => {
       const [success, error] = await getRootSkillTree();
@@ -114,7 +120,11 @@ export default {
     }
 
     function scrollToNode(row: number, column: number, smooth: boolean) {
-      nextNode.value = { row: row, column: column };
+      nextNode.value = { row, column };
+
+      if (!panzoomInstance.value) {
+        pendingTarget.value = { row, column };
+      }
 
       scrollMapToNode(
         map,
@@ -123,7 +133,8 @@ export default {
         zoomLevel.value,
         row,
         column,
-        smooth
+        smooth,
+        panzoomInstance.value ?? undefined
       );
     }
 
@@ -211,24 +222,48 @@ export default {
     }
 
     // ! ======================================================= Controls
-    const zoomLevel = ref(-1);
+    const zoomLevel = ref(2);
     const showMap = ref(false);
 
-    watch(
-      () => zoomLevel.value,
-      (newValue, oldValue) => {
-        if (newValue != oldValue) {
-          setupComplete.value = false;
-          nextTick(() => {
-            createPathways();
-            let row = nextNode.value.row;
-            let column = nextNode.value.column;
-            scrollToNode(row, column, false);
-            setupComplete.value = true;
-          });
-        }
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const instance = panzoomInstance.value;
+      if (!instance) return;
+
+      const delta =
+        event.deltaY === 0 && event.deltaX ? event.deltaX : event.deltaY;
+      if (!delta) return;
+
+      const intensity = clamp(Math.abs(delta) / 120, 0.2, 4);
+      const step = clamp(
+        intensity * ZOOM_BASE_STEP,
+        MIN_WHEEL_STEP,
+        MAX_WHEEL_STEP
+      );
+
+      instance.zoomWithWheel(event, { step, animate: false });
+    };
+
+    function initializePanzoom() {
+      if (!svgRef.value || !mainRef.value || panzoomInstance.value) return;
+
+      const instance = Panzoom(svgRef.value, {
+        maxScale: MAX_SCALE,
+        minScale: MIN_SCALE,
+        step: 0.1,
+        cursor: "grab",
+      });
+
+      panzoomInstance.value = instance;
+      mainRef.value.addEventListener("wheel", handleWheel, { passive: false });
+      mainRef.value.style.touchAction = "none";
+
+      if (pendingTarget.value) {
+        const { row, column } = pendingTarget.value;
+        pendingTarget.value = null;
+        nextTick(() => scrollToNode(row, column, false));
       }
-    );
+    }
 
     watch(
       () => map,
@@ -248,50 +283,22 @@ export default {
       { immediate: true, deep: true }
     );
 
-    // ! ======================================================= Dragging
-    const isDragging = ref(false);
-    const startX = ref(0);
-    const startY = ref(0);
-    const scrollLeft = ref(0);
-    const scrollTop = ref(0);
-
-    const startDrag = (event: MouseEvent) => {
-      if (event.button !== 0) return;
-
-      const target = event.target as HTMLElement;
-      console.log(target.tagName);
-      if (target.tagName === "foreignObject" || target.tagName === "path") return;
-
-      isDragging.value = true;
-      startX.value = event.pageX - mainRef.value!.offsetLeft;
-      startY.value = event.pageY - mainRef.value!.offsetTop;
-      scrollLeft.value = mainRef.value!.scrollLeft;
-      scrollTop.value = mainRef.value!.scrollTop;
-      document.addEventListener("mousemove", drag);
-      document.addEventListener("mouseup", stopDrag);
-    };
-
-    const drag = (event: MouseEvent) => {
-      if (!isDragging.value) return;
-      event.preventDefault();
-      const x = event.pageX - mainRef.value!.offsetLeft;
-      const y = event.pageY - mainRef.value!.offsetTop;
-      const walkX = x - startX.value;
-      const walkY = y - startY.value;
-      
-      mainRef.value!.scrollLeft = scrollLeft.value - walkX;
-      mainRef.value!.scrollTop = scrollTop.value - walkY;
-
-      if (event.clientX <= 0 || event.clientX >= window.innerWidth || event.clientY <= 0 || event.clientY >= window.innerHeight) {
-        stopDrag();
+    watch(
+      () => setupComplete.value,
+      (complete) => {
+        if (complete) {
+          nextTick(() => initializePanzoom());
+        }
       }
-    };
+    );
 
-    const stopDrag = () => {
-      isDragging.value = false;
-      document.removeEventListener("mousemove", drag);
-      document.removeEventListener("mouseup", stopDrag);
-    };
+    onUnmounted(() => {
+      if (mainRef.value) {
+        mainRef.value.removeEventListener("wheel", handleWheel);
+      }
+      panzoomInstance.value?.destroy();
+      panzoomInstance.value = null;
+    });
 
     return {
       user,
@@ -322,10 +329,7 @@ export default {
       onclickUploadCertificates,
       ArrowUpTrayIcon,
       breadcrumbs,
-      
-      isDragging,
-      startDrag,
-      
+      svgRef,
       xp,
     };
   },

--- a/pages/skill-tree/index.vue
+++ b/pages/skill-tree/index.vue
@@ -13,14 +13,28 @@
     >
       <svg ref="svgRef" :width="mapWidth" :height="mapHeight" :viewBox="mapViewBox">
         <g v-if="setupComplete">
-          <SkillTreePathway v-for="(pathway, p) of pathways" :key="p" :pathway="pathway.path" :zoomLevel="zoomLevel"
-            @click="scrollViaPathway(pathway.node, pathway.parent)" />
+          <SkillTreePathway
+            v-for="(pathway, p) of pathways"
+            :key="p"
+            :pathway="pathway.path"
+            @click="scrollViaPathway(pathway.node, pathway.parent)"
+          />
         </g>
 
         <template v-for="(row, i) in map" :key="i">
-          <SkillTreeNode v-for="(column, j) in row" :key="`${i}${j}`" :row="i" :column="j"
-            @ref="insertRefInMap($event, i, j)" :node="getNode(i, j)" :zoomLevel="zoomLevel" @size="nodeSize = $event"
-            @click="scrollToNode(i, j, true)" view-subtree :completed="getNode(i, j) && getNode(i, j).id == 'start'" :xp="xp" />
+          <SkillTreeNode
+            v-for="(column, j) in row"
+            :key="`${i}${j}`"
+            :row="i"
+            :column="j"
+            @ref="insertRefInMap($event, i, j)"
+            :node="getNode(i, j)"
+            @size="nodeSize = $event"
+            @click="scrollToNode(i, j, true)"
+            view-subtree
+            :completed="getNode(i, j) && getNode(i, j).id == 'start'"
+            :xp="xp"
+          />
         </template>
       </svg>
     </section>
@@ -130,7 +144,6 @@ export default {
         map,
         mainRef.value,
         nodeSize.value,
-        zoomLevel.value,
         row,
         column,
         smooth,
@@ -222,9 +235,6 @@ export default {
     }
 
     // ! ======================================================= Controls
-    const zoomLevel = ref(2);
-    const showMap = ref(false);
-
     const handleWheel = (event: WheelEvent) => {
       event.preventDefault();
       const instance = panzoomInstance.value;
@@ -323,8 +333,6 @@ export default {
       pathways,
       scrollViaPathway,
 
-      zoomLevel,
-      showMap,
       t,
       onclickUploadCertificates,
       ArrowUpTrayIcon,


### PR DESCRIPTION
## Summary
- integrate panzoom-based drag+zoom for root and sub skill trees
- keep breadcrumb header clickable and remove obsolete zoom buttons
- center scroll/zoom via composable updates for map anchoring

## Test plan
- [ ] npm run lint
- [ ] npm run dev
