### PR TITLE
Refresh privacy policy for microservice stack

### DIFF
--- a/pages/docs/privacy.vue
+++ b/pages/docs/privacy.vue
@@ -1,26 +1,26 @@
-<template>
+﻿<template>
 	<main class="container mt-main mb-main">
-		<h1>Datenschutzhinweise f├╝r Bootstrap Academy</h1>
+		<h1>Datenschutzhinweise für Bootstrap Academy</h1>
 
 		<section id="einleitung">
 			<h2>1 Einleitung</h2>
 			<p>
-				Mit den nachfolgenden Datenschutzhinweisen informieren wir Sie dar├╝ber,
+				Mit den nachfolgenden Datenschutzhinweisen informieren wir Sie darüber,
 				wie wir personenbezogene Daten beim Besuch unserer Webseiten, der Nutzung
-				unserer Lernplattform sowie der zugeh├Ârigen Microservices (Skills, Jobs,
-				Events, Challenges) verarbeiten. Die Hinweise gelten f├╝r die Produktiv-
+				unserer Lernplattform sowie der zugehörigen Microservices (Skills, Jobs,
+				Events, Challenges) verarbeiten. Die Hinweise gelten für die Produktiv-
 				und Testumgebungen unter
 				<a href="https://bootstrap.academy" target="_blank" rel="noopener noreferrer">bootstrap.academy</a>,
 				<a href="https://test.bootstrap.academy" target="_blank" rel="noopener noreferrer">test.bootstrap.academy</a>
 				und verbundene Subdomains (z.&nbsp;B. sandkasten.bootstrap.academy) sowie
-				f├╝r die Kommunikation per E-Mail oder Support.
+				für die Kommunikation per E-Mail oder Support.
 			</p>
 			<p>
-				Wir verarbeiten personenbezogene Daten ausschlie├ƒlich im Einklang mit der
+				Wir verarbeiten personenbezogene Daten ausschließlich im Einklang mit der
 				Datenschutz-Grundverordnung (DSGVO), dem Bundesdatenschutzgesetz (BDSG)
 				und dem Telekommunikation-Telemedien-Datenschutz-Gesetz (TTDSG). In den
-				nachfolgenden Abschnitten erl├ñutern wir, welche Daten zu welchem Zweck,
-				auf welcher Rechtsgrundlage und f├╝r welche Dauer verarbeitet werden und
+				nachfolgenden Abschnitten erläutern wir, welche Daten zu welchem Zweck,
+				auf welcher Rechtsgrundlage und für welche Dauer verarbeitet werden und
 				welche Rechte Ihnen zustehen.
 			</p>
 		</section>
@@ -30,26 +30,26 @@
 			<li><a href="#datenschutzbeauftragter">Datenschutzbeauftragter</a></li>
 			<li><a href="#geltungsbereich">Geltungsbereich und Systeme</a></li>
 			<li><a href="#rechtsgrundlagen">Rechtsgrundlagen</a></li>
-			<li><a href="#ueberblick">├£berblick Verarbeitungst├ñtigkeiten</a></li>
+			<li><a href="#ueberblick">Überblick Verarbeitungstätigkeiten</a></li>
 			<li><a href="#hosting">Hosting und Auftragsverarbeitung</a></li>
 			<li><a href="#serverlogs">Server-Logs und Systemsicherheit</a></li>
 			<li><a href="#cookies">Cookies und lokale Speichertechnologien</a></li>
 			<li><a href="#konto">Benutzerkonto und Authentifizierung</a></li>
 			<li><a href="#lernen">Lernplattform, Kursfortschritt und Gamification</a></li>
-			<li><a href="#challenges">Challenges und Code-Ausf├╝hrung</a></li>
+			<li><a href="#challenges">Challenges und Code-Ausführung</a></li>
 			<li><a href="#jobs">Jobs und Karriereangebote</a></li>
-			<li><a href="#events">Events, Webinare und Community-Aktivit├ñten</a></li>
+			<li><a href="#events">Events, Webinare und Community-Aktivitäten</a></li>
 			<li><a href="#zahlungen">Zahlungsabwicklung</a></li>
 			<li><a href="#newsletter">Newsletter und Produktinformationen</a></li>
 			<li><a href="#kommunikation">Kontakt, Support und Kommunikation</a></li>
 			<li><a href="#analyse">Analyse und Produktentwicklung</a></li>
 			<li><a href="#botschutz">Bot- und Missbrauchsschutz</a></li>
-			<li><a href="#drittland">Drittland├╝bermittlungen und Garantien</a></li>
-			<li><a href="#speicherung">Speicherdauer und L├Âschung</a></li>
+			<li><a href="#drittland">Drittlandübermittlungen und Garantien</a></li>
+			<li><a href="#speicherung">Speicherdauer und Löschung</a></li>
 			<li><a href="#pflichtangaben">Pflichtangaben und Freiwilligkeit</a></li>
 			<li><a href="#rechte">Ihre Datenschutzrechte</a></li>
-			<li><a href="#aufsicht">Beschwerderecht bei Aufsichtsbeh├Ârden</a></li>
-			<li><a href="#aenderungen">├änderungen dieser Hinweise</a></li>
+			<li><a href="#aufsicht">Beschwerderecht bei Aufsichtsbehörden</a></li>
+			<li><a href="#aenderungen">änderungen dieser Hinweise</a></li>
 		</ol>
 
 		<section id="verantwortliche">
@@ -58,7 +58,7 @@
 			<p>
 				bootstrap academy GmbH<br />
 				Wittelsbacherplatz 1<br />
-				80333 M├╝nchen<br />
+				80333 München<br />
 				Telefon: +49 89 24 88 62 51 - 0<br />
 				E-Mail:
 				<a href="mailto:hallo@bootstrap.academy" class="underline-link">hallo@bootstrap.academy</a>
@@ -71,21 +71,21 @@
 			<p>
 				Niklas Hanitsch<br />
 				secjur GmbH<br />
-				Steinh├Âft 9<br />
+				Steinhöft 9<br />
 				20459 Hamburg<br />
 				Telefon: +49 40 228 599 520<br />
 				E-Mail:
 				<a href="mailto:dsb@secjur.com" class="underline-link">dsb@secjur.com</a>
 			</p>
-			<p>Bitte nutzen Sie diese Kontakte f├╝r alle Fragen zum Datenschutz oder zur Aus├╝bung Ihrer Rechte.</p>
+			<p>Bitte nutzen Sie diese Kontakte für alle Fragen zum Datenschutz oder zur Ausübung Ihrer Rechte.</p>
 		</section>
 
 		<section id="geltungsbereich">
 			<h2>4 Geltungsbereich und Systeme</h2>
-			<p>Diese Hinweise gelten f├╝r:</p>
+			<p>Diese Hinweise gelten für:</p>
 			<ul>
 				<li>
-					die ├Âffentliche Webpr├ñsenz unter
+					die öffentliche Webpräsenz unter
 					<a href="https://bootstrap.academy" target="_blank" rel="noopener noreferrer">bootstrap.academy</a>
 					und
 					<a href="https://test.bootstrap.academy" target="_blank" rel="noopener noreferrer">test.bootstrap.academy</a>,
@@ -94,13 +94,13 @@
 					die registrierungspflichtige Lernplattform inklusive der Microservices Skills, Jobs, Events und
 					Challenges,
 				</li>
-				<li>interne Admin-Dashboards f├╝r autorisierte Mitarbeitende,</li>
+				<li>interne Admin-Dashboards für autorisierte Mitarbeitende,</li>
 				<li>
-					verbundene Dienste wie der Code-Ausf├╝hrungsdienst unter sandkasten.bootstrap.academy, Newsletter- und
+					verbundene Dienste wie der Code-Ausführungsdienst unter sandkasten.bootstrap.academy, Newsletter- und
 					Support-Kommunikation.
 				</li>
 			</ul>
-			<p>F├╝r externe Angebote, auf die wir verlinken, gelten deren eigene Datenschutzbestimmungen.</p>
+			<p>Für externe Angebote, auf die wir verlinken, gelten deren eigene Datenschutzbestimmungen.</p>
 		</section>
 
 		<section id="rechtsgrundlagen">
@@ -108,29 +108,29 @@
 			<p>Wir verarbeiten personenbezogene Daten insbesondere auf Basis der folgenden Rechtsgrundlagen:</p>
 			<ul>
 				<li>
-					<strong>Art. 6 Abs. 1 lit. b DSGVO</strong> ÔÇô zur Erf├╝llung vertraglicher Pflichten, z.&nbsp;B.
+					<strong>Art. 6 Abs. 1 lit. b DSGVO</strong> ÔÇô zur Erfüllung vertraglicher Pflichten, z.&nbsp;B.
 					Bereitstellung der Lernplattform, Kurs- und Eventteilnahme, Jobvermittlung.
 				</li>
 				<li>
-					<strong>Art. 6 Abs. 1 lit. c DSGVO</strong> ÔÇô zur Erf├╝llung rechtlicher Verpflichtungen, etwa steuer-
+					<strong>Art. 6 Abs. 1 lit. c DSGVO</strong> ÔÇô zur Erfüllung rechtlicher Verpflichtungen, etwa steuer-
 					und handelsrechtliche Aufbewahrungspflichten.
 				</li>
 				<li>
-					<strong>Art. 6 Abs. 1 lit. a DSGVO</strong> ÔÇô auf Basis einer Einwilligung, z.&nbsp;B. f├╝r Newsletter,
-					OAuth-Verkn├╝pfungen oder optionale Komfortfunktionen.
+					<strong>Art. 6 Abs. 1 lit. a DSGVO</strong> ÔÇô auf Basis einer Einwilligung, z.&nbsp;B. für Newsletter,
+					OAuth-Verknüpfungen oder optionale Komfortfunktionen.
 				</li>
 				<li>
 					<strong>Art. 6 Abs. 1 lit. f DSGVO</strong> ÔÇô zur Wahrung berechtigter Interessen wie Plattformsicherheit,
 					Missbrauchserkennung, Fehleranalyse und Produktoptimierung, sofern Ihre Interessen nicht entgegenstehen.
 				</li>
 			</ul>
-			<p>F├╝r Bewerbungen gilt erg├ñnzend ┬º 26 Abs. 1 BDSG. Auf zus├ñtzliche Rechtsgrundlagen weisen wir in den jeweiligen Abschnitten hin.</p>
+			<p>Für Bewerbungen gilt ergänzend º 26 Abs. 1 BDSG. Auf zusätzliche Rechtsgrundlagen weisen wir in den jeweiligen Abschnitten hin.</p>
 		</section>
 
 		<section id="ueberblick">
-			<h2>6 ├£berblick Verarbeitungst├ñtigkeiten</h2>
+			<h2>6 Überblick Verarbeitungstätigkeiten</h2>
 			<p>
-				Die folgende ├£bersicht fasst die wichtigsten Verarbeitungst├ñtigkeiten zusammen. Ausf├╝hrliche Informationen
+				Die folgende Übersicht fasst die wichtigsten Verarbeitungstätigkeiten zusammen. Ausführliche Informationen
 				finden Sie in den nachfolgenden Abschnitten.
 			</p>
 			<table>
@@ -141,7 +141,7 @@
 						<th>Datenkategorien</th>
 						<th>Rechtsgrundlage</th>
 						<th>Speicherdauer</th>
-						<th>Empf├ñnger</th>
+						<th>Empfänger</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -149,14 +149,14 @@
 						<td>Webseitenbesuch &amp; Server-Logs</td>
 						<td>Technischer Betrieb, Sicherheit, Fehlerdiagnose</td>
 						<td>IP-Adresse, Zeitstempel, URL, HTTP-Status, Referrer, User-Agent</td>
-						<td>Art. 6 Abs. 1 lit. f DSGVO; ┬º 25 Abs. 2 TTDSG</td>
-						<td>14ÔÇô30 Tage, l├ñngere Aufbewahrung bei Sicherheitsvorf├ñllen</td>
+						<td>Art. 6 Abs. 1 lit. f DSGVO; º 25 Abs. 2 TTDSG</td>
+						<td>14ÔÇô30 Tage, längere Aufbewahrung bei Sicherheitsvorfällen</td>
 						<td>Interne IT, Hosting-Provider, Sicherheitsdienstleister</td>
 					</tr>
 					<tr>
 						<td>Consent-Management &amp; Cookie-Nachweis</td>
-						<td>Dokumentation von Einwilligungen, Cookie-Pr├ñferenzen</td>
-						<td>Pseudonyme ID, Einwilligungsstatus, Zeitstempel, Ger├ñtetyp</td>
+						<td>Dokumentation von Einwilligungen, Cookie-Präferenzen</td>
+						<td>Pseudonyme ID, Einwilligungsstatus, Zeitstempel, Gerätetyp</td>
 						<td>Art. 6 Abs. 1 lit. c DSGVO, Art. 6 Abs. 1 lit. f DSGVO; optional Art. 6 Abs. 1 lit. a DSGVO</td>
 						<td>6ÔÇô12 Monate bzw. bis Widerruf/Nachweisablauf</td>
 						<td>Interne Systeme (kein externer CMP-Dienst)</td>
@@ -171,39 +171,39 @@
 					</tr>
 					<tr>
 						<td>OAuth-Anmeldung</td>
-						<td>Alternative Login-Verfahren ├╝ber GitHub, Google, Discord</td>
+						<td>Alternative Login-Verfahren über GitHub, Google, Discord</td>
 						<td>OAuth-Anbieter-ID, Profilname, E-Mail (optional), Token-Metadaten</td>
 						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. a DSGVO (Einwilligung)</td>
-						<td>Bis zur Aufhebung der Verkn├╝pfung oder Kontol├Âschung</td>
+						<td>Bis zur Aufhebung der Verknüpfung oder Kontolöschung</td>
 						<td>GitHub Inc., Google LLC, Discord Inc. (USA, Standardvertragsklauseln)</td>
 					</tr>
 					<tr>
 						<td>Lernfortschritt &amp; Skills</td>
 						<td>Kurse, Aufgaben, XP-System, Lernempfehlungen</td>
-						<td>Kursstatus, Aufgabenl├Âsungen, Kommentare, XP, Badges, Zeitpunkte</td>
+						<td>Kursstatus, Aufgabenlösungen, Kommentare, XP, Badges, Zeitpunkte</td>
 						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. f DSGVO (Produktverbesserung)</td>
-						<td>Bis Kontol├Âschung; aggregierte Statistiken 12 Monate</td>
+						<td>Bis Kontolöschung; aggregierte Statistiken 12 Monate</td>
 						<td>Skills-Microservice, internes Produktteam</td>
 					</tr>
 					<tr>
-						<td>Challenges &amp; Code-Ausf├╝hrung</td>
+						<td>Challenges &amp; Code-Ausführung</td>
 						<td>Bewertung von Programmieraufgaben, Betrugserkennung</td>
 						<td>Aufgaben-ID, Code, Testergebnisse, Laufzeitdaten, Telemetrie</td>
 						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. f DSGVO</td>
-						<td>Rohdaten i.&nbsp;d.&nbsp;R. 30 Tage, Ergebnisse bis Kontol├Âschung</td>
+						<td>Rohdaten i.&nbsp;d.&nbsp;R. 30 Tage, Ergebnisse bis Kontolöschung</td>
 						<td>Challenges-Microservice, Sandkasten-Dienst (EU)</td>
 					</tr>
 					<tr>
 						<td>Jobs &amp; Karriereangebote</td>
-						<td>Ver├Âffentlichung von Stellen, Weiterleitung von Bewerbungen</td>
+						<td>Veröffentlichung von Stellen, Weiterleitung von Bewerbungen</td>
 						<td>Stammdaten, Lebenslauf, Kontaktdaten, Bewerbungsunterlagen, Kommunikationsverlauf</td>
-						<td>┬º 26 Abs. 1 BDSG; Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. a DSGVO (Talentpool)</td>
-						<td>6 Monate nach Abschluss des Verfahrens, Verl├ñngerung mit Einwilligung</td>
+						<td>º 26 Abs. 1 BDSG; Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. a DSGVO (Talentpool)</td>
+						<td>6 Monate nach Abschluss des Verfahrens, Verlängerung mit Einwilligung</td>
 						<td>Bootstrap Academy HR, ggf. einstellende Unternehmen, Auftragsverarbeiter</td>
 					</tr>
 					<tr>
 						<td>Events, Coachings &amp; Community</td>
-						<td>Planung, Durchf├╝hrung, Teilnahmeverwaltung, Feedback</td>
+						<td>Planung, Durchführung, Teilnahmeverwaltung, Feedback</td>
 						<td>Registrierungsdaten, Termine, Teilnahmehistorie, Bewertungen, iCal-Daten</td>
 						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. f DSGVO</td>
 						<td>12 Monate nach Event; Abrechnungsdaten 10 Jahre</td>
@@ -215,27 +215,27 @@
 						<td>Rechnungsadresse, Zahlungsreferenzen, Vertragsdetails, PayPal-Transaktions-ID</td>
 						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. c DSGVO; Art. 6 Abs. 1 lit. f DSGVO</td>
 						<td>10 Jahre (Handels- und Steuerrecht)</td>
-						<td>PayPal (Europe) S.├á r.l. et Cie S.C.A., Steuerberatung, Finanzbeh├Ârden</td>
+						<td>PayPal (Europe) S.à r.l. et Cie S.C.A., Steuerberatung, Finanzbehörden</td>
 					</tr>
 					<tr>
 						<td>Newsletter &amp; Produktkommunikation</td>
 						<td>Informationen zu Kursen, Events, Angeboten</td>
-						<td>E-Mail-Adresse, Opt-In-Status, Pr├ñferenzen, Versand- und ├ûffnungsstatistiken (pseudonym)</td>
-						<td>Art. 6 Abs. 1 lit. a DSGVO; ┬º 7 UWG</td>
+						<td>E-Mail-Adresse, Opt-In-Status, Präferenzen, Versand- und Öffnungsstatistiken (pseudonym)</td>
+						<td>Art. 6 Abs. 1 lit. a DSGVO; º 7 UWG</td>
 						<td>Bis Widerruf + 3 Jahre Nachweisfrist</td>
 						<td>E-Mail/Newsletter-Dienstleister, interne Marketingteams</td>
 					</tr>
 					<tr>
 						<td>Kontakt &amp; Support</td>
 						<td>Bearbeitung von Anfragen, Fehleranalysen, Community-Support</td>
-						<td>Kontaktinformationen, Inhalte, Anh├ñnge, Metadaten, Log-IDs</td>
+						<td>Kontaktinformationen, Inhalte, Anhänge, Metadaten, Log-IDs</td>
 						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. f DSGVO</td>
-						<td>3 Jahre nach Abschluss, l├ñngstens zur Anspruchsverteidigung</td>
+						<td>3 Jahre nach Abschluss, längstens zur Anspruchsverteidigung</td>
 						<td>Support-Team, ggf. Ticket- oder Kommunikationsdienstleister</td>
 					</tr>
 					<tr>
 						<td>Analyse &amp; Produktentwicklung</td>
-						<td>Nutzungsanalysen, Feature-Planung, Leistungs├╝berwachung</td>
+						<td>Nutzungsanalysen, Feature-Planung, Leistungsüberwachung</td>
 						<td>Pseudonymisierte Nutzungskennzahlen, aggregierte Statistiken, Fehlerberichte</td>
 						<td>Art. 6 Abs. 1 lit. f DSGVO</td>
 						<td>Aggregierte Daten i.&nbsp;d.&nbsp;R. 12 Monate</td>
@@ -248,10 +248,10 @@
 		<section id="hosting">
 			<h2>7 Hosting und Auftragsverarbeitung</h2>
 			<p>
-				Unsere Plattform wird in Rechenzentren innerhalb der Europ├ñischen Union betrieben. F├╝r den Betrieb nutzen
-				wir ausgew├ñhlte Infrastruktur-, E-Mail- und Zahlungsdienstleister, mit denen wir datenschutzrechtliche
-				Auftragsverarbeitungsvertr├ñge nach Art. 28 DSGVO abgeschlossen haben. Diese Dienstleister verarbeiten Daten
-				nur nach dokumentierter Weisung und unter Einhaltung angemessener technischer und organisatorischer Ma├ƒnahmen.
+				Unsere Plattform wird in Rechenzentren innerhalb der Europäischen Union betrieben. Für den Betrieb nutzen
+				wir ausgewählte Infrastruktur-, E-Mail- und Zahlungsdienstleister, mit denen wir datenschutzrechtliche
+				Auftragsverarbeitungsverträge nach Art. 28 DSGVO abgeschlossen haben. Diese Dienstleister verarbeiten Daten
+				nur nach dokumentierter Weisung und unter Einhaltung angemessener technischer und organisatorischer Maßnahmen.
 			</p>
 		</section>
 
@@ -260,23 +260,23 @@
 			<p>
 				Bei jedem Zugriff auf unsere Dienste verarbeiten wir technisch bedingte Server-Logfiles (IP-Adresse,
 				Zeitpunkt, aufgerufene Ressourcen, User-Agent, Referrer, HTTP-Status). Die Verarbeitung dient der
-				Fehlerdiagnose, Systemsicherheit, Missbrauchsabwehr und Nachvollziehbarkeit von Supportf├ñllen. Die
-				Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO i.&nbsp;V.&nbsp;m. ┬º 25 Abs. 2 TTDSG. Logdaten werden in der
-				Regel nach 30 Tagen gel├Âscht; l├ñngere Aufbewahrung erfolgt nur anlassbezogen f├╝r die Aufkl├ñrung von
-				Sicherheitsvorf├ñllen.
+				Fehlerdiagnose, Systemsicherheit, Missbrauchsabwehr und Nachvollziehbarkeit von Supportfällen. Die
+				Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO i.&nbsp;V.&nbsp;m. º 25 Abs. 2 TTDSG. Logdaten werden in der
+				Regel nach 30 Tagen gelöscht; längere Aufbewahrung erfolgt nur anlassbezogen für die Aufklärung von
+				Sicherheitsvorfällen.
 			</p>
 		</section>
 
 		<section id="cookies">
 			<h2>9 Cookies und lokale Speichertechnologien</h2>
 			<p>
-				Wir setzen ausschlie├ƒlich eigene (First-Party-)Cookies, Session-Storage und Local-Storage ein. Diese sind
+				Wir setzen ausschließlich eigene (First-Party-)Cookies, Session-Storage und Local-Storage ein. Diese sind
 				technisch erforderlich, um die Lernplattform bereitzustellen, Nutzereinstellungen zu speichern und
 				Sicherheitsmechanismen umzusetzen. Optional einwilligungspflichtige Analyse- oder Marketing-Cookies werden
-				derzeit nicht gesetzt. Sollten k├╝nftig zus├ñtzliche Technologien eingesetzt werden, fragen wir vorab Ihre
+				derzeit nicht gesetzt. Sollten künftig zusätzliche Technologien eingesetzt werden, fragen wir vorab Ihre
 				Einwilligung ab.
 			</p>
-			<p>Die wichtigsten Cookies und Speicherobjekte im ├£berblick:</p>
+			<p>Die wichtigsten Cookies und Speicherobjekte im Überblick:</p>
 			<table>
 				<thead>
 					<tr>
@@ -297,19 +297,19 @@
 						<td>Komfortfunktionen (z.&nbsp;B. <code>locale</code>, <code>job_filters</code>, <code>zoomLevel</code>, <code>lastViewCourse</code>, <code>currentVideo</code>)</td>
 						<td>Speicherung von Sprache, Filter- und Anzeigeeinstellungen, Lernfortschritt in Videos</td>
 						<td>Funktional</td>
-						<td>Sitzungsende oder bis Sie die Daten l├Âschen (max. 12 Monate vorgesehen)</td>
+						<td>Sitzungsende oder bis Sie die Daten löschen (max. 12 Monate vorgesehen)</td>
 					</tr>
 					<tr>
 						<td>Einwilligungsnachweis (<code>agreedToCookiePolicy</code>)</td>
-						<td>Dokumentation Ihrer Cookie-Pr├ñferenz</td>
-						<td>Unbedingt erforderlich (┬º 25 Abs. 2 TTDSG)</td>
+						<td>Dokumentation Ihrer Cookie-Präferenz</td>
+						<td>Unbedingt erforderlich (º 25 Abs. 2 TTDSG)</td>
 						<td>6 Monate bzw. bis Widerruf</td>
 					</tr>
 				</tbody>
 			</table>
 			<p>
-				Sie k├Ânnen Cookies und Local-Storage-Eintr├ñge jederzeit ├╝ber Ihre Browser-Einstellungen l├Âschen oder blockieren.
-				Bitte beachten Sie, dass der Verzicht auf essenzielle Cookies die Funktionalit├ñt der Plattform einschr├ñnken kann.
+				Sie können Cookies und Local-Storage-Einträge jederzeit über Ihre Browser-Einstellungen löschen oder blockieren.
+				Bitte beachten Sie, dass der Verzicht auf essenzielle Cookies die Funktionalität der Plattform einschränken kann.
 			</p>
 		</section>
 
@@ -318,14 +318,14 @@
 			<p>
 				Um die Lernplattform zu nutzen, ist ein kostenloses Benutzerkonto erforderlich. Wir verarbeiten dabei
 				zwingend erforderliche Daten (Name, E-Mail-Adresse, Passwort-Hash) sowie freiwillige Profilangaben
-				(bspw. Anzeigename, Avatar, Kurzbeschreibung, Tags). Zus├ñtzlich speichern wir Sitzungs- und Refresh-Tokens,
+				(bspw. Anzeigename, Avatar, Kurzbeschreibung, Tags). Zusätzlich speichern wir Sitzungs- und Refresh-Tokens,
 				E-Mail-Verifizierungsstatus, Mehrfaktor-Authentifizierung, Rollen (z.&nbsp;B. Dozierende, Admins) und
 				Abonnement-Informationen. Rechtsgrundlagen sind Art. 6 Abs. 1 lit. b und lit. c DSGVO. Wir archivieren Konto-
-				und Vertragsdaten f├╝r 3 Jahre nach Vertragsende, abrechnungsrelevante Daten f├╝r 10 Jahre.
+				und Vertragsdaten für 3 Jahre nach Vertragsende, abrechnungsrelevante Daten für 10 Jahre.
 			</p>
 			<p>
 				Administrator:innen haben nur auf vertraglich notwendige Daten Zugriff. Zugriffe werden protokolliert und
-				regelm├ñ├ƒig ├╝berpr├╝ft. Bei K├╝ndigung l├Âschen wir Ihr Konto innerhalb von 30 Tagen, sofern keine gesetzlichen
+				regelmäßig überprüft. Bei Kündigung löschen wir Ihr Konto innerhalb von 30 Tagen, sofern keine gesetzlichen
 				Aufbewahrungspflichten entgegenstehen.
 			</p>
 		</section>
@@ -335,42 +335,42 @@
 			<p>
 				Im Skills-Microservice speichern wir Kursbuchungen, Lernpfade, Aufgabenstatus, Punkte (XP), Herzen,
 				Bewertungen, Notizen, hochgeladene Materialien sowie Interaktionen mit Lerninhalten. Die Verarbeitung dient
-				der Vertragserf├╝llung (Art. 6 Abs. 1 lit. b DSGVO) und unserem berechtigten Interesse an einer
+				der Vertragserfüllung (Art. 6 Abs. 1 lit. b DSGVO) und unserem berechtigten Interesse an einer
 				benutzerfreundlichen Lernplattform (Art. 6 Abs. 1 lit. f DSGVO). Aufgabenergebnisse und Fortschrittsdaten
-				werden bis zur Kontol├Âschung vorgehalten; aggregierte Auswertungen speichern wir maximal 12 Monate.
+				werden bis zur Kontolöschung vorgehalten; aggregierte Auswertungen speichern wir maximal 12 Monate.
 			</p>
 		</section>
 
 		<section id="challenges">
-			<h2>12 Challenges und Code-Ausf├╝hrung</h2>
+			<h2>12 Challenges und Code-Ausführung</h2>
 			<p>
 				Bei Programmier-Challenges verarbeiten wir die von Ihnen eingereichten Codes, Test- und Bewertungsdaten,
-				Logs der Code-Ausf├╝hrung sowie Zeit- und Ergebnisdaten. Die Verarbeitung erfolgt zur Vertragserf├╝llung
-				(Art. 6 Abs. 1 lit. b DSGVO) und zur Betrugsvermeidung (Art. 6 Abs. 1 lit. f DSGVO). Code-Ausf├╝hrungen
+				Logs der Code-Ausführung sowie Zeit- und Ergebnisdaten. Die Verarbeitung erfolgt zur Vertragserfüllung
+				(Art. 6 Abs. 1 lit. b DSGVO) und zur Betrugsvermeidung (Art. 6 Abs. 1 lit. f DSGVO). Code-Ausführungen
 				erfolgen in unserem Sandkasten-Dienst innerhalb der EU. Rohdaten werden in der Regel nach 30 Tagen
-				automatisch gel├Âscht; Ergebnis- und Punkteinformationen verbleiben in Ihrem Konto, bis Sie dieses l├Âschen.
+				automatisch gelöscht; Ergebnis- und Punkteinformationen verbleiben in Ihrem Konto, bis Sie dieses löschen.
 			</p>
 		</section>
 
 		<section id="jobs">
 			<h2>13 Jobs und Karriereangebote</h2>
 			<p>
-				├£ber den Jobs-Microservice k├Ânnen Unternehmen Stellen ver├Âffentlichen und Bewerbende sich informieren oder
+				Über den Jobs-Microservice können Unternehmen Stellen veröffentlichen und Bewerbende sich informieren oder
 				bewerben. Wir verarbeiten dabei Kontaktdaten der Unternehmensansprechpartner, Stelleninhalte sowie ÔÇô bei
 				Bewerbungen ÔÇô die von Ihnen bereitgestellten Unterlagen (Lebenslauf, Motivationsschreiben, Referenzen).
 				Bewerbungsdaten speichern wir nach Abschluss des Prozesses sechs Monate zur Rechtsverteidigung (Art. 6 Abs. 1
-				lit. b DSGVO, ┬º 26 Abs. 1 BDSG). Mit Ihrer Einwilligung speichern wir Unterlagen l├ñnger f├╝r einen Talentpool.
+				lit. b DSGVO, º 26 Abs. 1 BDSG). Mit Ihrer Einwilligung speichern wir Unterlagen länger für einen Talentpool.
 				Eine Weitergabe an die ausschreibenden Unternehmen erfolgt nur zur Bearbeitung Ihrer Bewerbung.
 			</p>
 		</section>
 
 		<section id="events">
-			<h2>14 Events, Webinare und Community-Aktivit├ñten</h2>
+			<h2>14 Events, Webinare und Community-Aktivitäten</h2>
 			<p>
-				F├╝r Events, Coachings und Community-Angebote verarbeiten wir Registrierungsdaten (Name, E-Mail, Status),
+				Für Events, Coachings und Community-Angebote verarbeiten wir Registrierungsdaten (Name, E-Mail, Status),
 				Teilnahmen, Feedback, Kalenderdaten (iCal) sowie ggf. Informationen zu vergebenen XP. Rechtsgrundlage ist
 				Art. 6 Abs. 1 lit. b DSGVO; Feedbackauswertungen erfolgen auf Basis unseres berechtigten Interesses
-				(Art. 6 Abs. 1 lit. f DSGVO). Eventdaten werden 12 Monate nach Durchf├╝hrung gel├Âscht, sofern keine gesetzlichen
+				(Art. 6 Abs. 1 lit. f DSGVO). Eventdaten werden 12 Monate nach Durchführung gelöscht, sofern keine gesetzlichen
 				Pflichten entgegenstehen.
 			</p>
 		</section>
@@ -378,11 +378,11 @@
 		<section id="zahlungen">
 			<h2>15 Zahlungsabwicklung</h2>
 			<p>
-				Premium-Mitgliedschaften und kostenpflichtige Events werden ├╝ber PayPal abgewickelt. Wir erhalten von PayPal
-				Transaktionskennungen, Zahlstatus und ÔÇô sofern ├╝bermittelt ÔÇô die Rechnungsadresse. Die Verarbeitung ist zur
-				Vertragserf├╝llung (Art. 6 Abs. 1 lit. b DSGVO) und zur Erf├╝llung steuerrechtlicher Pflichten
+				Premium-Mitgliedschaften und kostenpflichtige Events werden über PayPal abgewickelt. Wir erhalten von PayPal
+				Transaktionskennungen, Zahlstatus und ÔÇô sofern übermittelt ÔÇô die Rechnungsadresse. Die Verarbeitung ist zur
+				Vertragserfüllung (Art. 6 Abs. 1 lit. b DSGVO) und zur Erfüllung steuerrechtlicher Pflichten
 				(Art. 6 Abs. 1 lit. c DSGVO) erforderlich. Nach Handels- und Steuerrecht bewahren wir Rechnungsunterlagen
-				zehn Jahre auf. Zahlungen werden ├╝ber PayPal (Europe) S.├á r.l. et Cie S.C.A. mit Sitz in Luxemburg abgewickelt.
+				zehn Jahre auf. Zahlungen werden über PayPal (Europe) S.à r.l. et Cie S.C.A. mit Sitz in Luxemburg abgewickelt.
 			</p>
 		</section>
 
@@ -390,20 +390,20 @@
 			<h2>16 Newsletter und Produktinformationen</h2>
 			<p>
 				Mit Ihrer Einwilligung senden wir Newsletter, Produkt- und Eventupdates. Wir verwenden das
-				Double-Opt-In-Verfahren und protokollieren Anmeldung, Best├ñtigung, Zeitstempel und IP-Adresse zum Nachweis
-				(Art. 6 Abs. 1 lit. a DSGVO, ┬º 7 UWG). Sie k├Ânnen Ihre Einwilligung jederzeit ├╝ber den Abmeldelink oder per
+				Double-Opt-In-Verfahren und protokollieren Anmeldung, Bestätigung, Zeitstempel und IP-Adresse zum Nachweis
+				(Art. 6 Abs. 1 lit. a DSGVO, º 7 UWG). Sie können Ihre Einwilligung jederzeit über den Abmeldelink oder per
 				E-Mail an hallo@bootstrap.academy widerrufen. Nach Abmeldung speichern wir Ihre E-Mail-Adresse bis zu drei
-				Jahre in einer Sperrliste, um den Widerruf nachweisen zu k├Ânnen.
+				Jahre in einer Sperrliste, um den Widerruf nachweisen zu können.
 			</p>
 		</section>
 
 		<section id="kommunikation">
 			<h2>17 Kontakt, Support und Kommunikation</h2>
 			<p>
-				Wenn Sie uns kontaktieren (z.&nbsp;B. per E-Mail, Formular, Community-Kan├ñle), verarbeiten wir Ihre Angaben
-				zur Bearbeitung der Anfrage und f├╝r R├╝ckfragen. Rechtsgrundlage ist Art. 6 Abs. 1 lit. b DSGVO, bei allgemeinen
+				Wenn Sie uns kontaktieren (z.&nbsp;B. per E-Mail, Formular, Community-Kanäle), verarbeiten wir Ihre Angaben
+				zur Bearbeitung der Anfrage und für Rückfragen. Rechtsgrundlage ist Art. 6 Abs. 1 lit. b DSGVO, bei allgemeinen
 				Anfragen Art. 6 Abs. 1 lit. f DSGVO. Kommunikationsdaten speichern wir bis zu drei Jahre nach Abschluss zur
-				Verteidigung m├Âglicher Rechtsanspr├╝che.
+				Verteidigung möglicher Rechtsansprüche.
 			</p>
 		</section>
 
@@ -411,17 +411,17 @@
 			<h2>18 Analyse und Produktentwicklung</h2>
 			<p>
 				Wir setzen keine Drittanbieter-Trackingdienste ein. Zur Weiterentwicklung der Plattform werten wir
-				pseudonymisierte Nutzungskennzahlen (z.&nbsp;B. aktive Nutzer:innen, Kursabschl├╝sse, Feature-Nutzung) und
-				Fehlerberichte auf unseren eigenen Systemen aus. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO. Sie k├Ânnen
-				dieser Verarbeitung widersprechen, wenn Gr├╝nde vorliegen, die sich aus Ihrer besonderen Situation ergeben.
+				pseudonymisierte Nutzungskennzahlen (z.&nbsp;B. aktive Nutzer:innen, Kursabschlüsse, Feature-Nutzung) und
+				Fehlerberichte auf unseren eigenen Systemen aus. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO. Sie können
+				dieser Verarbeitung widersprechen, wenn Gründe vorliegen, die sich aus Ihrer besonderen Situation ergeben.
 			</p>
 		</section>
 
 		<section id="botschutz">
 			<h2>19 Bot- und Missbrauchsschutz</h2>
 			<p>
-				Wir verwenden Google reCAPTCHA nur, wenn es f├╝r Formulare und Login-Schutz erforderlich ist. Hierbei k├Ânnen
-				Ihre IP-Adresse und weitere technische Informationen an Google LLC (USA) ├╝bermittelt werden. Rechtsgrundlagen
+				Wir verwenden Google reCAPTCHA nur, wenn es für Formulare und Login-Schutz erforderlich ist. Hierbei können
+				Ihre IP-Adresse und weitere technische Informationen an Google LLC (USA) übermittelt werden. Rechtsgrundlagen
 				sind Art. 6 Abs. 1 lit. f DSGVO (Schutz vor Missbrauch) sowie bei aktiver Nutzung Ihre Einwilligung
 				(Art. 6 Abs. 1 lit. a DSGVO). Google nutzt Standardvertragsklauseln; weitere Informationen finden Sie in den
 				Datenschutzhinweisen von Google.
@@ -429,26 +429,26 @@
 		</section>
 
 		<section id="drittland">
-			<h2>20 Drittland├╝bermittlungen und Garantien</h2>
+			<h2>20 Drittlandübermittlungen und Garantien</h2>
 			<p>
 				Einige Dienste (z.&nbsp;B. OAuth-Anbieter GitHub/Google/Discord, PayPal, Google reCAPTCHA) haben ihren Sitz
-				au├ƒerhalb des Europ├ñischen Wirtschaftsraums. F├╝r diese F├ñlle st├╝tzen wir Daten├╝bermittlungen auf
-				Standardvertragsklauseln der EU-Kommission und zus├ñtzliche Sicherheitsma├ƒnahmen. Weitere Informationen stellen
-				wir auf Anfrage gerne zur Verf├╝gung. Wenn eine Einwilligung erforderlich ist, informieren wir Sie gesondert.
+				außerhalb des Europäischen Wirtschaftsraums. Für diese Fälle stützen wir Datenübermittlungen auf
+				Standardvertragsklauseln der EU-Kommission und zusätzliche Sicherheitsmaßnahmen. Weitere Informationen stellen
+				wir auf Anfrage gerne zur Verfügung. Wenn eine Einwilligung erforderlich ist, informieren wir Sie gesondert.
 			</p>
 		</section>
 
 		<section id="speicherung">
-			<h2>21 Speicherdauer und L├Âschung</h2>
+			<h2>21 Speicherdauer und Löschung</h2>
 			<p>
-				Wir verarbeiten und speichern personenbezogene Daten nur so lange, wie es f├╝r den jeweiligen Zweck oder
+				Wir verarbeiten und speichern personenbezogene Daten nur so lange, wie es für den jeweiligen Zweck oder
 				gesetzliche Aufbewahrungspflichten erforderlich ist. Nach Wegfall des Zwecks oder Ablauf gesetzlicher Fristen
-				l├Âschen oder anonymisieren wir die Daten. Konkret gelten u.&nbsp;a. folgende Fristen:
+				löschen oder anonymisieren wir die Daten. Konkret gelten u.&nbsp;a. folgende Fristen:
 			</p>
 			<ul>
 				<li>Konto- und Vertragsdaten: bis drei Jahre nach Vertragsende.</li>
-				<li>Abrechnungs- und Steuerunterlagen: zehn Jahre (┬º┬º 147 AO, 257 HGB).</li>
-				<li>Bewerbungsunterlagen: sechs Monate nach Abschluss (l├ñngere Aufbewahrung nur mit Einwilligung).</li>
+				<li>Abrechnungs- und Steuerunterlagen: zehn Jahre (ºº 147 AO, 257 HGB).</li>
+				<li>Bewerbungsunterlagen: sechs Monate nach Abschluss (längere Aufbewahrung nur mit Einwilligung).</li>
 				<li>Support-Kommunikation: bis zu drei Jahre.</li>
 				<li>Server-Logs und Telemetrie: 14ÔÇô30 Tage.</li>
 			</ul>
@@ -457,7 +457,7 @@
 		<section id="pflichtangaben">
 			<h2>22 Pflichtangaben und Freiwilligkeit</h2>
 			<p>
-				Zur Registrierung sind Name, E-Mail-Adresse und ein Passwort erforderlich. Ohne diese Angaben k├Ânnen wir
+				Zur Registrierung sind Name, E-Mail-Adresse und ein Passwort erforderlich. Ohne diese Angaben können wir
 				Ihnen die Plattform nicht bereitstellen. Alle weiteren Angaben (z.&nbsp;B. Profilinfos, Newsletter,
 				Talentpool) sind freiwillig. Wenn wir weitere Angaben als Pflichtfelder erheben, markieren wir dies
 				gesondert.
@@ -466,38 +466,38 @@
 
 		<section id="rechte">
 			<h2>23 Ihre Datenschutzrechte</h2>
-			<p>Ihnen stehen die folgenden Rechte gem├ñ├ƒ Art. 15ÔÇô22 DSGVO zu:</p>
+			<p>Ihnen stehen die folgenden Rechte gemäß Art. 15ÔÇô22 DSGVO zu:</p>
 			<ul>
-				<li>Auskunft ├╝ber die Verarbeitung Ihrer personenbezogenen Daten,</li>
-				<li>Berichtigung unrichtiger oder Vervollst├ñndigung unvollst├ñndiger Daten,</li>
-				<li>L├Âschung personenbezogener Daten (Recht auf Vergessenwerden),</li>
-				<li>Einschr├ñnkung der Verarbeitung,</li>
-				<li>Daten├╝bertragbarkeit,</li>
+				<li>Auskunft über die Verarbeitung Ihrer personenbezogenen Daten,</li>
+				<li>Berichtigung unrichtiger oder Vervollständigung unvollständiger Daten,</li>
+				<li>Löschung personenbezogener Daten (Recht auf Vergessenwerden),</li>
+				<li>Einschränkung der Verarbeitung,</li>
+				<li>Datenübertragbarkeit,</li>
 				<li>Widerspruch gegen Verarbeitungen auf Grundlage von Art. 6 Abs. 1 lit. e oder lit. f DSGVO,</li>
-				<li>Widerruf erteilter Einwilligungen mit Wirkung f├╝r die Zukunft.</li>
+				<li>Widerruf erteilter Einwilligungen mit Wirkung für die Zukunft.</li>
 			</ul>
 			<p>
 				Bitte richten Sie Ihre Anliegen an
 				<a href="mailto:hallo@bootstrap.academy" class="underline-link">hallo@bootstrap.academy</a>
-				oder an unseren Datenschutzbeauftragten. Zur Bearbeitung Ihrer Anfrage k├Ânnen wir zus├ñtzliche Angaben zur
-				Identit├ñtspr├╝fung ben├Âtigen.
+				oder an unseren Datenschutzbeauftragten. Zur Bearbeitung Ihrer Anfrage können wir zusätzliche Angaben zur
+				Identitätsprüfung benötigen.
 			</p>
 		</section>
 
 		<section id="aufsicht">
-			<h2>24 Beschwerderecht bei Aufsichtsbeh├Ârden</h2>
+			<h2>24 Beschwerderecht bei Aufsichtsbehörden</h2>
 			<p>
-				Sie haben das Recht, sich bei einer Datenschutzaufsichtsbeh├Ârde zu beschweren, insbesondere in dem
-				Mitgliedstaat Ihres gew├Âhnlichen Aufenthaltsorts, Ihres Arbeitsplatzes oder des Orts des mutma├ƒlichen
-				Versto├ƒes (Art. 77 DSGVO). F├╝r uns zust├ñndig ist insbesondere das Bayerische Landesamt f├╝r Datenschutzaufsicht
+				Sie haben das Recht, sich bei einer Datenschutzaufsichtsbehörde zu beschweren, insbesondere in dem
+				Mitgliedstaat Ihres gewöhnlichen Aufenthaltsorts, Ihres Arbeitsplatzes oder des Orts des mutmaßlichen
+				Verstoßes (Art. 77 DSGVO). Für uns zuständig ist insbesondere das Bayerische Landesamt für Datenschutzaufsicht
 				(BayLDA), Promenade 27, 91522 Ansbach, Deutschland.
 			</p>
 		</section>
 
 		<section id="aenderungen">
-			<h2>25 ├änderungen dieser Hinweise</h2>
+			<h2>25 änderungen dieser Hinweise</h2>
 			<p>
-				Wir passen diese Datenschutzhinweise an, sobald ├änderungen unserer Datenverarbeitung oder gesetzlicher
+				Wir passen diese Datenschutzhinweise an, sobald änderungen unserer Datenverarbeitung oder gesetzlicher
 				Vorgaben dies erforderlich machen. Die jeweils aktuelle Fassung ist jederzeit unter
 				<a
 					href="https://bootstrap.academy/docs/privacy"

--- a/pages/docs/privacy.vue
+++ b/pages/docs/privacy.vue
@@ -108,23 +108,23 @@
 			<p>Wir verarbeiten personenbezogene Daten insbesondere auf Basis der folgenden Rechtsgrundlagen:</p>
 			<ul>
 				<li>
-					<strong>Art. 6 Abs. 1 lit. b DSGVO</strong> ÔÇô zur Erfüllung vertraglicher Pflichten, z.&nbsp;B.
+					<strong>Art. 6 Abs. 1 lit. b DSGVO</strong> – zur Erfüllung vertraglicher Pflichten, z.&nbsp;B.
 					Bereitstellung der Lernplattform, Kurs- und Eventteilnahme, Jobvermittlung.
 				</li>
 				<li>
-					<strong>Art. 6 Abs. 1 lit. c DSGVO</strong> ÔÇô zur Erfüllung rechtlicher Verpflichtungen, etwa steuer-
+					<strong>Art. 6 Abs. 1 lit. c DSGVO</strong> – zur Erfüllung rechtlicher Verpflichtungen, etwa steuer-
 					und handelsrechtliche Aufbewahrungspflichten.
 				</li>
 				<li>
-					<strong>Art. 6 Abs. 1 lit. a DSGVO</strong> ÔÇô auf Basis einer Einwilligung, z.&nbsp;B. für Newsletter,
+					<strong>Art. 6 Abs. 1 lit. a DSGVO</strong> – auf Basis einer Einwilligung, z.&nbsp;B. für Newsletter,
 					OAuth-Verknüpfungen oder optionale Komfortfunktionen.
 				</li>
 				<li>
-					<strong>Art. 6 Abs. 1 lit. f DSGVO</strong> ÔÇô zur Wahrung berechtigter Interessen wie Plattformsicherheit,
+					<strong>Art. 6 Abs. 1 lit. f DSGVO</strong> – zur Wahrung berechtigter Interessen wie Plattformsicherheit,
 					Missbrauchserkennung, Fehleranalyse und Produktoptimierung, sofern Ihre Interessen nicht entgegenstehen.
 				</li>
 			</ul>
-			<p>Für Bewerbungen gilt ergänzend º 26 Abs. 1 BDSG. Auf zusätzliche Rechtsgrundlagen weisen wir in den jeweiligen Abschnitten hin.</p>
+			<p>Für Bewerbungen gilt ergänzend § 26 Abs. 1 BDSG. Auf zusätzliche Rechtsgrundlagen weisen wir in den jeweiligen Abschnitten hin.</p>
 		</section>
 
 		<section id="ueberblick">
@@ -149,8 +149,8 @@
 						<td>Webseitenbesuch &amp; Server-Logs</td>
 						<td>Technischer Betrieb, Sicherheit, Fehlerdiagnose</td>
 						<td>IP-Adresse, Zeitstempel, URL, HTTP-Status, Referrer, User-Agent</td>
-						<td>Art. 6 Abs. 1 lit. f DSGVO; º 25 Abs. 2 TTDSG</td>
-						<td>14ÔÇô30 Tage, längere Aufbewahrung bei Sicherheitsvorfällen</td>
+						<td>Art. 6 Abs. 1 lit. f DSGVO; § 25 Abs. 2 TTDSG</td>
+						<td>14–30 Tage, längere Aufbewahrung bei Sicherheitsvorfällen</td>
 						<td>Interne IT, Hosting-Provider, Sicherheitsdienstleister</td>
 					</tr>
 					<tr>
@@ -158,7 +158,7 @@
 						<td>Dokumentation von Einwilligungen, Cookie-Präferenzen</td>
 						<td>Pseudonyme ID, Einwilligungsstatus, Zeitstempel, Gerätetyp</td>
 						<td>Art. 6 Abs. 1 lit. c DSGVO, Art. 6 Abs. 1 lit. f DSGVO; optional Art. 6 Abs. 1 lit. a DSGVO</td>
-						<td>6ÔÇô12 Monate bzw. bis Widerruf/Nachweisablauf</td>
+						<td>6–12 Monate bzw. bis Widerruf/Nachweisablauf</td>
 						<td>Interne Systeme (kein externer CMP-Dienst)</td>
 					</tr>
 					<tr>
@@ -197,7 +197,7 @@
 						<td>Jobs &amp; Karriereangebote</td>
 						<td>Veröffentlichung von Stellen, Weiterleitung von Bewerbungen</td>
 						<td>Stammdaten, Lebenslauf, Kontaktdaten, Bewerbungsunterlagen, Kommunikationsverlauf</td>
-						<td>º 26 Abs. 1 BDSG; Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. a DSGVO (Talentpool)</td>
+						<td>§ 26 Abs. 1 BDSG; Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. a DSGVO (Talentpool)</td>
 						<td>6 Monate nach Abschluss des Verfahrens, Verlängerung mit Einwilligung</td>
 						<td>Bootstrap Academy HR, ggf. einstellende Unternehmen, Auftragsverarbeiter</td>
 					</tr>
@@ -221,7 +221,7 @@
 						<td>Newsletter &amp; Produktkommunikation</td>
 						<td>Informationen zu Kursen, Events, Angeboten</td>
 						<td>E-Mail-Adresse, Opt-In-Status, Präferenzen, Versand- und Öffnungsstatistiken (pseudonym)</td>
-						<td>Art. 6 Abs. 1 lit. a DSGVO; º 7 UWG</td>
+						<td>Art. 6 Abs. 1 lit. a DSGVO; § 7 UWG</td>
 						<td>Bis Widerruf + 3 Jahre Nachweisfrist</td>
 						<td>E-Mail/Newsletter-Dienstleister, interne Marketingteams</td>
 					</tr>
@@ -261,7 +261,7 @@
 				Bei jedem Zugriff auf unsere Dienste verarbeiten wir technisch bedingte Server-Logfiles (IP-Adresse,
 				Zeitpunkt, aufgerufene Ressourcen, User-Agent, Referrer, HTTP-Status). Die Verarbeitung dient der
 				Fehlerdiagnose, Systemsicherheit, Missbrauchsabwehr und Nachvollziehbarkeit von Supportfällen. Die
-				Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO i.&nbsp;V.&nbsp;m. º 25 Abs. 2 TTDSG. Logdaten werden in der
+				Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO i.&nbsp;V.&nbsp;m. § 25 Abs. 2 TTDSG. Logdaten werden in der
 				Regel nach 30 Tagen gelöscht; längere Aufbewahrung erfolgt nur anlassbezogen für die Aufklärung von
 				Sicherheitsvorfällen.
 			</p>
@@ -302,7 +302,7 @@
 					<tr>
 						<td>Einwilligungsnachweis (<code>agreedToCookiePolicy</code>)</td>
 						<td>Dokumentation Ihrer Cookie-Präferenz</td>
-						<td>Unbedingt erforderlich (º 25 Abs. 2 TTDSG)</td>
+						<td>Unbedingt erforderlich (§ 25 Abs. 2 TTDSG)</td>
 						<td>6 Monate bzw. bis Widerruf</td>
 					</tr>
 				</tbody>
@@ -356,10 +356,10 @@
 			<h2>13 Jobs und Karriereangebote</h2>
 			<p>
 				Über den Jobs-Microservice können Unternehmen Stellen veröffentlichen und Bewerbende sich informieren oder
-				bewerben. Wir verarbeiten dabei Kontaktdaten der Unternehmensansprechpartner, Stelleninhalte sowie ÔÇô bei
-				Bewerbungen ÔÇô die von Ihnen bereitgestellten Unterlagen (Lebenslauf, Motivationsschreiben, Referenzen).
+				bewerben. Wir verarbeiten dabei Kontaktdaten der Unternehmensansprechpartner, Stelleninhalte sowie – bei
+				Bewerbungen – die von Ihnen bereitgestellten Unterlagen (Lebenslauf, Motivationsschreiben, Referenzen).
 				Bewerbungsdaten speichern wir nach Abschluss des Prozesses sechs Monate zur Rechtsverteidigung (Art. 6 Abs. 1
-				lit. b DSGVO, º 26 Abs. 1 BDSG). Mit Ihrer Einwilligung speichern wir Unterlagen länger für einen Talentpool.
+				lit. b DSGVO, § 26 Abs. 1 BDSG). Mit Ihrer Einwilligung speichern wir Unterlagen länger für einen Talentpool.
 				Eine Weitergabe an die ausschreibenden Unternehmen erfolgt nur zur Bearbeitung Ihrer Bewerbung.
 			</p>
 		</section>
@@ -379,7 +379,7 @@
 			<h2>15 Zahlungsabwicklung</h2>
 			<p>
 				Premium-Mitgliedschaften und kostenpflichtige Events werden über PayPal abgewickelt. Wir erhalten von PayPal
-				Transaktionskennungen, Zahlstatus und ÔÇô sofern übermittelt ÔÇô die Rechnungsadresse. Die Verarbeitung ist zur
+				Transaktionskennungen, Zahlstatus und – sofern übermittelt – die Rechnungsadresse. Die Verarbeitung ist zur
 				Vertragserfüllung (Art. 6 Abs. 1 lit. b DSGVO) und zur Erfüllung steuerrechtlicher Pflichten
 				(Art. 6 Abs. 1 lit. c DSGVO) erforderlich. Nach Handels- und Steuerrecht bewahren wir Rechnungsunterlagen
 				zehn Jahre auf. Zahlungen werden über PayPal (Europe) S.à r.l. et Cie S.C.A. mit Sitz in Luxemburg abgewickelt.
@@ -391,7 +391,7 @@
 			<p>
 				Mit Ihrer Einwilligung senden wir Newsletter, Produkt- und Eventupdates. Wir verwenden das
 				Double-Opt-In-Verfahren und protokollieren Anmeldung, Bestätigung, Zeitstempel und IP-Adresse zum Nachweis
-				(Art. 6 Abs. 1 lit. a DSGVO, º 7 UWG). Sie können Ihre Einwilligung jederzeit über den Abmeldelink oder per
+				(Art. 6 Abs. 1 lit. a DSGVO, § 7 UWG). Sie können Ihre Einwilligung jederzeit über den Abmeldelink oder per
 				E-Mail an hallo@bootstrap.academy widerrufen. Nach Abmeldung speichern wir Ihre E-Mail-Adresse bis zu drei
 				Jahre in einer Sperrliste, um den Widerruf nachweisen zu können.
 			</p>
@@ -447,10 +447,10 @@
 			</p>
 			<ul>
 				<li>Konto- und Vertragsdaten: bis drei Jahre nach Vertragsende.</li>
-				<li>Abrechnungs- und Steuerunterlagen: zehn Jahre (ºº 147 AO, 257 HGB).</li>
+				<li>Abrechnungs- und Steuerunterlagen: zehn Jahre (§§ 147 AO, 257 HGB).</li>
 				<li>Bewerbungsunterlagen: sechs Monate nach Abschluss (längere Aufbewahrung nur mit Einwilligung).</li>
 				<li>Support-Kommunikation: bis zu drei Jahre.</li>
-				<li>Server-Logs und Telemetrie: 14ÔÇô30 Tage.</li>
+				<li>Server-Logs und Telemetrie: 14–30 Tage.</li>
 			</ul>
 		</section>
 
@@ -466,7 +466,7 @@
 
 		<section id="rechte">
 			<h2>23 Ihre Datenschutzrechte</h2>
-			<p>Ihnen stehen die folgenden Rechte gemäß Art. 15ÔÇô22 DSGVO zu:</p>
+			<p>Ihnen stehen die folgenden Rechte gemäß Art. 15–22 DSGVO zu:</p>
 			<ul>
 				<li>Auskunft über die Verarbeitung Ihrer personenbezogenen Daten,</li>
 				<li>Berichtigung unrichtiger oder Vervollständigung unvollständiger Daten,</li>

--- a/pages/docs/privacy.vue
+++ b/pages/docs/privacy.vue
@@ -1,989 +1,513 @@
-<!--
-✅ Responsive UI
-✅ Page Title
-✅ Animation
-
-❌ Tested on chrome
-❌ Tested on firefox
-❌ Tested on safari
-❌ Tested on android mobile
-❌ Tested on apple mobile
--->
-
 <template>
 	<main class="container mt-main mb-main">
-		<h1>Datenschutzhinweise Website</h1>
+		<h1>Datenschutzhinweise f├╝r Bootstrap Academy</h1>
 
-		<article>
-			<h2>Einleitung</h2>
+		<section id="einleitung">
+			<h2>1 Einleitung</h2>
 			<p>
-				Mit den nachfolgenden Informationen wollen wir Ihnen einen Überblick
-				über die Verarbeitung Ihrer personenbezogenen Daten auf unserer Website
-				www.bootstrap.academy (nachfolgend
-				<em>"Website"</em>
-				genannt) geben. Wir wollen Sie ebenfalls über Ihre Rechte aus den
-				Datenschutzgesetzen informieren. Die Verarbeitung Ihrer
-				personenbezogenen Daten durch uns erfolgt stets im Einklang mit der
-				Datenschutzgrundverordnung (nachfolgend
-				<em>"DSGVO"</em>
-				genannt) sowie allen geltenden landesspezifischen
-				Datenschutzbestimmungen.
+				Mit den nachfolgenden Datenschutzhinweisen informieren wir Sie dar├╝ber,
+				wie wir personenbezogene Daten beim Besuch unserer Webseiten, der Nutzung
+				unserer Lernplattform sowie der zugeh├Ârigen Microservices (Skills, Jobs,
+				Events, Challenges) verarbeiten. Die Hinweise gelten f├╝r die Produktiv-
+				und Testumgebungen unter
+				<a href="https://bootstrap.academy" target="_blank" rel="noopener noreferrer">bootstrap.academy</a>,
+				<a href="https://test.bootstrap.academy" target="_blank" rel="noopener noreferrer">test.bootstrap.academy</a>
+				und verbundene Subdomains (z.&nbsp;B. sandkasten.bootstrap.academy) sowie
+				f├╝r die Kommunikation per E-Mail oder Support.
 			</p>
-		</article>
+			<p>
+				Wir verarbeiten personenbezogene Daten ausschlie├ƒlich im Einklang mit der
+				Datenschutz-Grundverordnung (DSGVO), dem Bundesdatenschutzgesetz (BDSG)
+				und dem Telekommunikation-Telemedien-Datenschutz-Gesetz (TTDSG). In den
+				nachfolgenden Abschnitten erl├ñutern wir, welche Daten zu welchem Zweck,
+				auf welcher Rechtsgrundlage und f├╝r welche Dauer verarbeitet werden und
+				welche Rechte Ihnen zustehen.
+			</p>
+		</section>
 
 		<ol class="mt-container table-content">
-			<li><a href="#Verantwortlichkeit">Verantwortlichkeit</a></li>
-			<li><a href="#Datenschutzbeauftragter">Datenschutzbeauftragter</a></li>
-			<li><a href="#EinsatzVonDrittdiensten">Einsatz von Drittdiensten</a></li>
-			<li>
-				<a href="#BereitstellungDerWebsite">Bereitstellung der Website</a>
-			</li>
-			<li><a href="#Cookies">Cookies</a></li>
-			<li><a href="#Kontaktmöglichkeiten">Kontaktmöglichkeiten</a></li>
-			<li><a href="#Newsletter">Newsletter</a></li>
-			<li><a href="#Zahlungsdienstleister">Zahlungsdienstleister</a></li>
-			<li><a href="#SozialeNetzwerke">Soziale Netzwerke</a></li>
-			<li><a href="#IhreRechte">Ihre Rechte</a></li>
-			<li>
-				<a href="#AktualitätUndÄnderungenDerDatenschutzhinweise">
-					Aktualität und Änderungen der Datenschutzhinweise
-				</a>
-			</li>
+			<li><a href="#verantwortliche">Verantwortliche Stelle</a></li>
+			<li><a href="#datenschutzbeauftragter">Datenschutzbeauftragter</a></li>
+			<li><a href="#geltungsbereich">Geltungsbereich und Systeme</a></li>
+			<li><a href="#rechtsgrundlagen">Rechtsgrundlagen</a></li>
+			<li><a href="#ueberblick">├£berblick Verarbeitungst├ñtigkeiten</a></li>
+			<li><a href="#hosting">Hosting und Auftragsverarbeitung</a></li>
+			<li><a href="#serverlogs">Server-Logs und Systemsicherheit</a></li>
+			<li><a href="#cookies">Cookies und lokale Speichertechnologien</a></li>
+			<li><a href="#konto">Benutzerkonto und Authentifizierung</a></li>
+			<li><a href="#lernen">Lernplattform, Kursfortschritt und Gamification</a></li>
+			<li><a href="#challenges">Challenges und Code-Ausf├╝hrung</a></li>
+			<li><a href="#jobs">Jobs und Karriereangebote</a></li>
+			<li><a href="#events">Events, Webinare und Community-Aktivit├ñten</a></li>
+			<li><a href="#zahlungen">Zahlungsabwicklung</a></li>
+			<li><a href="#newsletter">Newsletter und Produktinformationen</a></li>
+			<li><a href="#kommunikation">Kontakt, Support und Kommunikation</a></li>
+			<li><a href="#analyse">Analyse und Produktentwicklung</a></li>
+			<li><a href="#botschutz">Bot- und Missbrauchsschutz</a></li>
+			<li><a href="#drittland">Drittland├╝bermittlungen und Garantien</a></li>
+			<li><a href="#speicherung">Speicherdauer und L├Âschung</a></li>
+			<li><a href="#pflichtangaben">Pflichtangaben und Freiwilligkeit</a></li>
+			<li><a href="#rechte">Ihre Datenschutzrechte</a></li>
+			<li><a href="#aufsicht">Beschwerderecht bei Aufsichtsbeh├Ârden</a></li>
+			<li><a href="#aenderungen">├änderungen dieser Hinweise</a></li>
 		</ol>
 
-		<section id="Verantwortlichkeit">
-			<h2>1 Verantwortlichkeit</h2>
-			<p>Verantwortlich im Sinne der DSGVO ist:</p>
+		<section id="verantwortliche">
+			<h2>2 Verantwortliche Stelle</h2>
+			<p>Verantwortlicher im Sinne der DSGVO ist:</p>
 			<p>
-				bootstrap academy GmbH
-				<br />
-				Wittelsbacherplatz 1, 80333 München
-				<br />
-				+49 89 24 88 62 51 - 0
-				<br />
-				hallo@bootstrap.academy
+				bootstrap academy GmbH<br />
+				Wittelsbacherplatz 1<br />
+				80333 M├╝nchen<br />
+				Telefon: +49 89 24 88 62 51 - 0<br />
+				E-Mail:
+				<a href="mailto:hallo@bootstrap.academy" class="underline-link">hallo@bootstrap.academy</a>
 			</p>
 		</section>
 
-		<section id="Datenschutzbeauftragter">
-			<h2>2 Datenschutzbeauftragter</h2>
-			<p>Unsere Datenschutzbeauftragten erreichen Sie wie folgt:</p>
+		<section id="datenschutzbeauftragter">
+			<h2>3 Datenschutzbeauftragter</h2>
+			<p>Unsere externe Datenschutzbeauftragte erreichen Sie wie folgt:</p>
 			<p>
-				Niklas Hanitsch
-				<br />
-				secjur GmbH
-				<br />
-				Steinhöft 9
-				<br />
-				20459 Hamburg
+				Niklas Hanitsch<br />
+				secjur GmbH<br />
+				Steinh├Âft 9<br />
+				20459 Hamburg<br />
+				Telefon: +49 40 228 599 520<br />
+				E-Mail:
+				<a href="mailto:dsb@secjur.com" class="underline-link">dsb@secjur.com</a>
 			</p>
-			<p>Telefon: +49 40 228 599 520</p>
-			<p>E-Mail: dsb@secjur.com</p>
+			<p>Bitte nutzen Sie diese Kontakte f├╝r alle Fragen zum Datenschutz oder zur Aus├╝bung Ihrer Rechte.</p>
+		</section>
+
+		<section id="geltungsbereich">
+			<h2>4 Geltungsbereich und Systeme</h2>
+			<p>Diese Hinweise gelten f├╝r:</p>
+			<ul>
+				<li>
+					die ├Âffentliche Webpr├ñsenz unter
+					<a href="https://bootstrap.academy" target="_blank" rel="noopener noreferrer">bootstrap.academy</a>
+					und
+					<a href="https://test.bootstrap.academy" target="_blank" rel="noopener noreferrer">test.bootstrap.academy</a>,
+				</li>
+				<li>
+					die registrierungspflichtige Lernplattform inklusive der Microservices Skills, Jobs, Events und
+					Challenges,
+				</li>
+				<li>interne Admin-Dashboards f├╝r autorisierte Mitarbeitende,</li>
+				<li>
+					verbundene Dienste wie der Code-Ausf├╝hrungsdienst unter sandkasten.bootstrap.academy, Newsletter- und
+					Support-Kommunikation.
+				</li>
+			</ul>
+			<p>F├╝r externe Angebote, auf die wir verlinken, gelten deren eigene Datenschutzbestimmungen.</p>
+		</section>
+
+		<section id="rechtsgrundlagen">
+			<h2>5 Rechtsgrundlagen</h2>
+			<p>Wir verarbeiten personenbezogene Daten insbesondere auf Basis der folgenden Rechtsgrundlagen:</p>
+			<ul>
+				<li>
+					<strong>Art. 6 Abs. 1 lit. b DSGVO</strong> ÔÇô zur Erf├╝llung vertraglicher Pflichten, z.&nbsp;B.
+					Bereitstellung der Lernplattform, Kurs- und Eventteilnahme, Jobvermittlung.
+				</li>
+				<li>
+					<strong>Art. 6 Abs. 1 lit. c DSGVO</strong> ÔÇô zur Erf├╝llung rechtlicher Verpflichtungen, etwa steuer-
+					und handelsrechtliche Aufbewahrungspflichten.
+				</li>
+				<li>
+					<strong>Art. 6 Abs. 1 lit. a DSGVO</strong> ÔÇô auf Basis einer Einwilligung, z.&nbsp;B. f├╝r Newsletter,
+					OAuth-Verkn├╝pfungen oder optionale Komfortfunktionen.
+				</li>
+				<li>
+					<strong>Art. 6 Abs. 1 lit. f DSGVO</strong> ÔÇô zur Wahrung berechtigter Interessen wie Plattformsicherheit,
+					Missbrauchserkennung, Fehleranalyse und Produktoptimierung, sofern Ihre Interessen nicht entgegenstehen.
+				</li>
+			</ul>
+			<p>F├╝r Bewerbungen gilt erg├ñnzend ┬º 26 Abs. 1 BDSG. Auf zus├ñtzliche Rechtsgrundlagen weisen wir in den jeweiligen Abschnitten hin.</p>
+		</section>
+
+		<section id="ueberblick">
+			<h2>6 ├£berblick Verarbeitungst├ñtigkeiten</h2>
 			<p>
-				Sie können sich jederzeit bei allen Fragen und Anregungen zum
-				Datenschutz sowie zur Ausübung Ihrer Rechte direkt an unsere
-				Datenschutzbeauftragten wenden.
+				Die folgende ├£bersicht fasst die wichtigsten Verarbeitungst├ñtigkeiten zusammen. Ausf├╝hrliche Informationen
+				finden Sie in den nachfolgenden Abschnitten.
 			</p>
+			<table>
+				<thead>
+					<tr>
+						<th>Verarbeitung</th>
+						<th>Zweck</th>
+						<th>Datenkategorien</th>
+						<th>Rechtsgrundlage</th>
+						<th>Speicherdauer</th>
+						<th>Empf├ñnger</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Webseitenbesuch &amp; Server-Logs</td>
+						<td>Technischer Betrieb, Sicherheit, Fehlerdiagnose</td>
+						<td>IP-Adresse, Zeitstempel, URL, HTTP-Status, Referrer, User-Agent</td>
+						<td>Art. 6 Abs. 1 lit. f DSGVO; ┬º 25 Abs. 2 TTDSG</td>
+						<td>14ÔÇô30 Tage, l├ñngere Aufbewahrung bei Sicherheitsvorf├ñllen</td>
+						<td>Interne IT, Hosting-Provider, Sicherheitsdienstleister</td>
+					</tr>
+					<tr>
+						<td>Consent-Management &amp; Cookie-Nachweis</td>
+						<td>Dokumentation von Einwilligungen, Cookie-Pr├ñferenzen</td>
+						<td>Pseudonyme ID, Einwilligungsstatus, Zeitstempel, Ger├ñtetyp</td>
+						<td>Art. 6 Abs. 1 lit. c DSGVO, Art. 6 Abs. 1 lit. f DSGVO; optional Art. 6 Abs. 1 lit. a DSGVO</td>
+						<td>6ÔÇô12 Monate bzw. bis Widerruf/Nachweisablauf</td>
+						<td>Interne Systeme (kein externer CMP-Dienst)</td>
+					</tr>
+					<tr>
+						<td>Benutzerkonto &amp; Authentifizierung</td>
+						<td>Bereitstellung des Accounts, Sitzungsverwaltung, Sicherheit</td>
+						<td>Name, E-Mail, Passwort-Hash, MFA-Status, Rollen, Sitzungs- und Token-IDs</td>
+						<td>Art. 6 Abs. 1 lit. b DSGVO, Art. 6 Abs. 1 lit. c DSGVO</td>
+						<td>Aktive Vertragsbeziehung + 3 Jahre; Abrechnungsdaten 10 Jahre</td>
+						<td>Backend, Auth- und Session-Microservices, interne Admin-Tools</td>
+					</tr>
+					<tr>
+						<td>OAuth-Anmeldung</td>
+						<td>Alternative Login-Verfahren ├╝ber GitHub, Google, Discord</td>
+						<td>OAuth-Anbieter-ID, Profilname, E-Mail (optional), Token-Metadaten</td>
+						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. a DSGVO (Einwilligung)</td>
+						<td>Bis zur Aufhebung der Verkn├╝pfung oder Kontol├Âschung</td>
+						<td>GitHub Inc., Google LLC, Discord Inc. (USA, Standardvertragsklauseln)</td>
+					</tr>
+					<tr>
+						<td>Lernfortschritt &amp; Skills</td>
+						<td>Kurse, Aufgaben, XP-System, Lernempfehlungen</td>
+						<td>Kursstatus, Aufgabenl├Âsungen, Kommentare, XP, Badges, Zeitpunkte</td>
+						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. f DSGVO (Produktverbesserung)</td>
+						<td>Bis Kontol├Âschung; aggregierte Statistiken 12 Monate</td>
+						<td>Skills-Microservice, internes Produktteam</td>
+					</tr>
+					<tr>
+						<td>Challenges &amp; Code-Ausf├╝hrung</td>
+						<td>Bewertung von Programmieraufgaben, Betrugserkennung</td>
+						<td>Aufgaben-ID, Code, Testergebnisse, Laufzeitdaten, Telemetrie</td>
+						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. f DSGVO</td>
+						<td>Rohdaten i.&nbsp;d.&nbsp;R. 30 Tage, Ergebnisse bis Kontol├Âschung</td>
+						<td>Challenges-Microservice, Sandkasten-Dienst (EU)</td>
+					</tr>
+					<tr>
+						<td>Jobs &amp; Karriereangebote</td>
+						<td>Ver├Âffentlichung von Stellen, Weiterleitung von Bewerbungen</td>
+						<td>Stammdaten, Lebenslauf, Kontaktdaten, Bewerbungsunterlagen, Kommunikationsverlauf</td>
+						<td>┬º 26 Abs. 1 BDSG; Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. a DSGVO (Talentpool)</td>
+						<td>6 Monate nach Abschluss des Verfahrens, Verl├ñngerung mit Einwilligung</td>
+						<td>Bootstrap Academy HR, ggf. einstellende Unternehmen, Auftragsverarbeiter</td>
+					</tr>
+					<tr>
+						<td>Events, Coachings &amp; Community</td>
+						<td>Planung, Durchf├╝hrung, Teilnahmeverwaltung, Feedback</td>
+						<td>Registrierungsdaten, Termine, Teilnahmehistorie, Bewertungen, iCal-Daten</td>
+						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. f DSGVO</td>
+						<td>12 Monate nach Event; Abrechnungsdaten 10 Jahre</td>
+						<td>Events-Microservice, Referent:innen, Zahlungsdienstleister</td>
+					</tr>
+					<tr>
+						<td>Zahlungsabwicklung</td>
+						<td>Abrechnung, Premium-Mitgliedschaften, Steuerpflichten</td>
+						<td>Rechnungsadresse, Zahlungsreferenzen, Vertragsdetails, PayPal-Transaktions-ID</td>
+						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. c DSGVO; Art. 6 Abs. 1 lit. f DSGVO</td>
+						<td>10 Jahre (Handels- und Steuerrecht)</td>
+						<td>PayPal (Europe) S.├á r.l. et Cie S.C.A., Steuerberatung, Finanzbeh├Ârden</td>
+					</tr>
+					<tr>
+						<td>Newsletter &amp; Produktkommunikation</td>
+						<td>Informationen zu Kursen, Events, Angeboten</td>
+						<td>E-Mail-Adresse, Opt-In-Status, Pr├ñferenzen, Versand- und ├ûffnungsstatistiken (pseudonym)</td>
+						<td>Art. 6 Abs. 1 lit. a DSGVO; ┬º 7 UWG</td>
+						<td>Bis Widerruf + 3 Jahre Nachweisfrist</td>
+						<td>E-Mail/Newsletter-Dienstleister, interne Marketingteams</td>
+					</tr>
+					<tr>
+						<td>Kontakt &amp; Support</td>
+						<td>Bearbeitung von Anfragen, Fehleranalysen, Community-Support</td>
+						<td>Kontaktinformationen, Inhalte, Anh├ñnge, Metadaten, Log-IDs</td>
+						<td>Art. 6 Abs. 1 lit. b DSGVO; Art. 6 Abs. 1 lit. f DSGVO</td>
+						<td>3 Jahre nach Abschluss, l├ñngstens zur Anspruchsverteidigung</td>
+						<td>Support-Team, ggf. Ticket- oder Kommunikationsdienstleister</td>
+					</tr>
+					<tr>
+						<td>Analyse &amp; Produktentwicklung</td>
+						<td>Nutzungsanalysen, Feature-Planung, Leistungs├╝berwachung</td>
+						<td>Pseudonymisierte Nutzungskennzahlen, aggregierte Statistiken, Fehlerberichte</td>
+						<td>Art. 6 Abs. 1 lit. f DSGVO</td>
+						<td>Aggregierte Daten i.&nbsp;d.&nbsp;R. 12 Monate</td>
+						<td>Interne Produkt- und Engineering-Teams</td>
+					</tr>
+				</tbody>
+			</table>
 		</section>
 
-		<section id="EinsatzVonDrittdiensten">
-			<h2>3 Einsatz von Drittdiensten</h2>
+		<section id="hosting">
+			<h2>7 Hosting und Auftragsverarbeitung</h2>
 			<p>
-				Für bestimmte Funktionen und Services auf unserer Website setzen wir
-				Dienste von Drittanbietern ein. Die konkreten Dienste können jeweils den
-				entsprechenden Kapiteln entnommen werden.
+				Unsere Plattform wird in Rechenzentren innerhalb der Europ├ñischen Union betrieben. F├╝r den Betrieb nutzen
+				wir ausgew├ñhlte Infrastruktur-, E-Mail- und Zahlungsdienstleister, mit denen wir datenschutzrechtliche
+				Auftragsverarbeitungsvertr├ñge nach Art. 28 DSGVO abgeschlossen haben. Diese Dienstleister verarbeiten Daten
+				nur nach dokumentierter Weisung und unter Einhaltung angemessener technischer und organisatorischer Ma├ƒnahmen.
+			</p>
+		</section>
+
+		<section id="serverlogs">
+			<h2>8 Server-Logs und Systemsicherheit</h2>
+			<p>
+				Bei jedem Zugriff auf unsere Dienste verarbeiten wir technisch bedingte Server-Logfiles (IP-Adresse,
+				Zeitpunkt, aufgerufene Ressourcen, User-Agent, Referrer, HTTP-Status). Die Verarbeitung dient der
+				Fehlerdiagnose, Systemsicherheit, Missbrauchsabwehr und Nachvollziehbarkeit von Supportf├ñllen. Die
+				Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO i.&nbsp;V.&nbsp;m. ┬º 25 Abs. 2 TTDSG. Logdaten werden in der
+				Regel nach 30 Tagen gel├Âscht; l├ñngere Aufbewahrung erfolgt nur anlassbezogen f├╝r die Aufkl├ñrung von
+				Sicherheitsvorf├ñllen.
+			</p>
+		</section>
+
+		<section id="cookies">
+			<h2>9 Cookies und lokale Speichertechnologien</h2>
+			<p>
+				Wir setzen ausschlie├ƒlich eigene (First-Party-)Cookies, Session-Storage und Local-Storage ein. Diese sind
+				technisch erforderlich, um die Lernplattform bereitzustellen, Nutzereinstellungen zu speichern und
+				Sicherheitsmechanismen umzusetzen. Optional einwilligungspflichtige Analyse- oder Marketing-Cookies werden
+				derzeit nicht gesetzt. Sollten k├╝nftig zus├ñtzliche Technologien eingesetzt werden, fragen wir vorab Ihre
+				Einwilligung ab.
+			</p>
+			<p>Die wichtigsten Cookies und Speicherobjekte im ├£berblick:</p>
+			<table>
+				<thead>
+					<tr>
+						<th>Name/Gruppe</th>
+						<th>Zweck</th>
+						<th>Kategorie</th>
+						<th>Speicherdauer</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>Authentifizierung (z.&nbsp;B. <code>accessToken</code>, <code>refreshToken</code>, <code>session</code>, <code>user</code>)</td>
+						<td>Anmeldung, Sitzungsverwaltung, Schutz vor unbefugtem Zugriff</td>
+						<td>Unbedingt erforderlich</td>
+						<td>Sitzungsende bzw. bis Abmeldung; Refresh-Tokens max. 30 Tage</td>
+					</tr>
+					<tr>
+						<td>Komfortfunktionen (z.&nbsp;B. <code>locale</code>, <code>job_filters</code>, <code>zoomLevel</code>, <code>lastViewCourse</code>, <code>currentVideo</code>)</td>
+						<td>Speicherung von Sprache, Filter- und Anzeigeeinstellungen, Lernfortschritt in Videos</td>
+						<td>Funktional</td>
+						<td>Sitzungsende oder bis Sie die Daten l├Âschen (max. 12 Monate vorgesehen)</td>
+					</tr>
+					<tr>
+						<td>Einwilligungsnachweis (<code>agreedToCookiePolicy</code>)</td>
+						<td>Dokumentation Ihrer Cookie-Pr├ñferenz</td>
+						<td>Unbedingt erforderlich (┬º 25 Abs. 2 TTDSG)</td>
+						<td>6 Monate bzw. bis Widerruf</td>
+					</tr>
+				</tbody>
+			</table>
+			<p>
+				Sie k├Ânnen Cookies und Local-Storage-Eintr├ñge jederzeit ├╝ber Ihre Browser-Einstellungen l├Âschen oder blockieren.
+				Bitte beachten Sie, dass der Verzicht auf essenzielle Cookies die Funktionalit├ñt der Plattform einschr├ñnken kann.
+			</p>
+		</section>
+
+		<section id="konto">
+			<h2>10 Benutzerkonto und Authentifizierung</h2>
+			<p>
+				Um die Lernplattform zu nutzen, ist ein kostenloses Benutzerkonto erforderlich. Wir verarbeiten dabei
+				zwingend erforderliche Daten (Name, E-Mail-Adresse, Passwort-Hash) sowie freiwillige Profilangaben
+				(bspw. Anzeigename, Avatar, Kurzbeschreibung, Tags). Zus├ñtzlich speichern wir Sitzungs- und Refresh-Tokens,
+				E-Mail-Verifizierungsstatus, Mehrfaktor-Authentifizierung, Rollen (z.&nbsp;B. Dozierende, Admins) und
+				Abonnement-Informationen. Rechtsgrundlagen sind Art. 6 Abs. 1 lit. b und lit. c DSGVO. Wir archivieren Konto-
+				und Vertragsdaten f├╝r 3 Jahre nach Vertragsende, abrechnungsrelevante Daten f├╝r 10 Jahre.
 			</p>
 			<p>
-				Teilweise setzen wir Dienstleister ein, die ihren Sitz in einem
-				Drittland haben, also außerhalb der EU. Wir übermitteln Daten nur in ein
-				Drittland, in denen ein angemessenes Datenschutzniveau bzw. geeignete
-				Garantien i. S. d. Art. 44-49 DSGVO vorliegen. Sie haben das Recht eine
-				Kopie der von uns getroffenen geeigneten Garantien anzufordern.
-				Schreiben Sie uns dazu gerne eine E-Mail an die in diesen
-				Datenschutzhinweisen genannte E-Mail-Adresse.
+				Administrator:innen haben nur auf vertraglich notwendige Daten Zugriff. Zugriffe werden protokolliert und
+				regelm├ñ├ƒig ├╝berpr├╝ft. Bei K├╝ndigung l├Âschen wir Ihr Konto innerhalb von 30 Tagen, sofern keine gesetzlichen
+				Aufbewahrungspflichten entgegenstehen.
 			</p>
 		</section>
 
-		<section id="BereitstellungDerWebsite">
-			<h2>4 Bereitstellung der Website</h2>
-			<article>
-				<h3>4.1 Allgemeine Informationen</h3>
-				<p>
-					Bei Besuch unserer Website werden automatisch Daten verarbeitet, die
-					Ihr Browser an unseren Server übermittelt. Diese allgemeinen Daten und
-					Informationen werden in den Logfiles des Servers gespeichert (in sog.
-					„Server-Logfiles“). Erfasst werden können die
-				</p>
-				<ul>
-					<li>Browsertyp und Browserversion</li>
-					<li>verwendetes Betriebssystem</li>
-					<li>Referrer URL (zuvor besuchte Website)</li>
-					<li>Hostname des zugreifenden Rechners</li>
-					<li>Datum und Uhrzeit der Serveranfrage</li>
-					<li>IP-Adresse</li>
-				</ul>
-			</article>
-
-			<article>
-				<h3>4.2 Zweck der Verarbeitung</h3>
-				<p>
-					Bei der Nutzung dieser allgemeinen Daten und Informationen ziehen wir
-					keine Rückschlüsse auf Ihre Person. Zu den von uns verfolgten Zwecken
-					gehört insbesondere:
-				</p>
-				<ul>
-					<li>
-						die Gewährleistung eines reibungslosen Verbindungsaufbaus der
-						Website,
-					</li>
-					<li>die Aufklärung von Missbrauchs- oder Betrugshandlungen,</li>
-					<li>Problemanalysen im Netzwerk, sowie</li>
-					<li>die Auswertung der Systemsicherheit und ‑stabilität.</li>
-				</ul>
-			</article>
-
-			<article>
-				<h3>4.3 Rechtsgrundlage</h3>
-				<p>
-					Die Rechtsgrundlage für die Datenverarbeitung ist unser berechtigtes
-					Interesse im Sinne des Art. 6 Abs. 1 S. 1 lit. f DSGVO. Wir haben ein
-					überwiegendes berechtigtes Interesse daran, unser Angebot technisch
-					einwandfrei anbieten zu können.
-				</p>
-			</article>
-
-			<article>
-				<h3>4.4 Speicherdauer</h3>
-				<p>
-					Die Logfiles werden aus Sicherheitsgründen (z.B. zur Aufklärung von
-					Missbrauchs- oder Betrugshandlungen) für die Dauer von maximal 7 Tagen
-					gespeichert und danach gelöscht. Daten, deren weitere Aufbewahrung zu
-					Beweiszwecken erforderlich ist, werden bis zur endgültigen Klärung der
-					Angelegenheit aufbewahrt.
-				</p>
-			</article>
+		<section id="lernen">
+			<h2>11 Lernplattform, Kursfortschritt und Gamification</h2>
+			<p>
+				Im Skills-Microservice speichern wir Kursbuchungen, Lernpfade, Aufgabenstatus, Punkte (XP), Herzen,
+				Bewertungen, Notizen, hochgeladene Materialien sowie Interaktionen mit Lerninhalten. Die Verarbeitung dient
+				der Vertragserf├╝llung (Art. 6 Abs. 1 lit. b DSGVO) und unserem berechtigten Interesse an einer
+				benutzerfreundlichen Lernplattform (Art. 6 Abs. 1 lit. f DSGVO). Aufgabenergebnisse und Fortschrittsdaten
+				werden bis zur Kontol├Âschung vorgehalten; aggregierte Auswertungen speichern wir maximal 12 Monate.
+			</p>
 		</section>
 
-		<section id="Cookies">
-			<h2>5 Cookies</h2>
-
-			<article>
-				<h3>5.1 Allgemeine Informationen</h3>
-				<p>
-					Wir setzen auf unserer Website Cookies ein. Dabei handelt es sich um
-					Textdateien, die Ihr Browser automatisch erstellt und die auf Ihrem
-					Endgerät gespeichert werden, wenn Sie unsere Seite besuchen. In dem
-					Cookie werden Informationen abgelegt, die sich jeweils im Zusammenhang
-					mit dem spezifisch eingesetzten Endgerät ergeben.
-				</p>
-			</article>
-
-			<article>
-				<h3>5.2 Technisch notwendige Cookies</h3>
-				<p>
-					Wir setzen technisch notwendige Cookies ein. Dabei handelt es sich um
-					Cookies, die technisch erforderlich sind, um alle Funktionen unserer
-					Website zur Verfügung zu stellen.
-				</p>
-
-				<div>
-					<h4>5.2.1 Zweck der Verarbeitung</h4>
-					<p>
-						Wir setzen technisch notwendige Cookies für folgende Zwecke ein, um:
-					</p>
-					<ul>
-						<li>Dienstleistungen anzubieten,</li>
-						<li>die Nutzung unserer Webseitenfunktionen zu ermöglichen,</li>
-						<li>sowie um verschiedene Sprachen anzubieten.</li>
-					</ul>
-				</div>
-
-				<div>
-					<h4>5.2.2 Rechtsgrundlage</h4>
-					<p>
-						Die Rechtsgrundlage für die Datenverarbeitung ist unser berechtigtes
-						Interesse im Sinne des Art. 6 Abs. 1 S. 1 lit. f DSGVO. Wir haben
-						ein überwiegendes berechtigtes Interesse daran, unser Angebot
-						technisch einwandfrei anbieten zu können.
-					</p>
-				</div>
-
-				<div>
-					<h4>5.2.3 Speicherdauer</h4>
-					<p>
-						Wir löschen Ihre personenbezogenen Daten, sobald sie für die
-						Erreichung des Zweckes der Erhebung nicht mehr erforderlich sind.
-						Technisch notwendige Cookies werden nur für jeweilige Session
-						gespeichert. Wenn Sie unsere Website verlassen und Ihren Browser
-						schließen, werden die Cookies gelöscht.
-					</p>
-				</div>
-			</article>
-
-			<article>
-				<h3>5.3 Analyse- und Marketing-Cookies</h3>
-				<p>
-					Wir setzen darüber hinaus auch Analyse- und Marketing-Cookies ein.
-					Dabei handelt es sich um Cookies, die technisch nicht erforderlich
-					sind. Wir setzen diese ein, um Ihr Verhalten auf unserer Website zu
-					verstehen und unser Angebot zu verbessern.
-				</p>
-
-				<div>
-					<h4>5.3.1 Zweck der Verarbeitung</h4>
-					<p>
-						Wir setzen technisch notwendige Cookies für folgende Zwecke ein:
-					</p>
-					<ul>
-						<li>Reichweitenmessung und Tracking,</li>
-						<li>Auswertung von Besucherverhalten,</li>
-						<li>Optimierung unseres Angebots,</li>
-						<li>sowie zielgerichtete Werbung.</li>
-					</ul>
-				</div>
-
-				<div>
-					<h4>5.3.2 Rechtsgrundlage</h4>
-					<p>
-						Die Rechtsgrundlage für die Datenverarbeitung ist Ihre Einwilligung
-						gem. Art. 6 Abs. 1 S. 1 lit. a DSGVO. Die Cookies werden erst
-						gesetzt, nachdem Sie Ihre Einwilligung über unseren Cookie Banner
-						erteil haben.
-					</p>
-				</div>
-
-				<div>
-					<h4>5.3.3 Speicherdauer</h4>
-					<p>
-						Wir löschen Ihre personenbezogenen Daten, sobald sie für die
-						Erreichung des Zweckes der Erhebung nicht mehr erforderlich sind.
-						Die Speicherdauer der personenbezogenen Daten richtet sich nach den
-						eingesetzten Anbietern.
-					</p>
-				</div>
-
-				<div>
-					<h4>5.3.4 Empfänger personenbezogener Daten</h4>
-					<p>Wir setzen folgende Dienstleister ein:</p>
-					<div class="overflow-x-auto">
-						<table>
-							<tr>
-								<th>Dienst</th>
-								<th>Anbieter</th>
-								<th>Zweck</th>
-								<th>Rechtsgrundlage</th>
-								<th>Speicherdauer</th>
-							</tr>
-							<tr>
-								<td>Google Recaptcha</td>
-								<td>
-									Google Ireland Limited Gordon House, Barrow Street, Dublin 4,
-									Irland
-								</td>
-								<td>Optimierung unseres Online-Angebots</td>
-								<td>Ihre Einwilligung gem. Art. 6 Abs. 1 S. 1 lit. a DSGVO</td>
-								<td>
-									Wir löschen Ihre personenbezogenen Daten, sobald sie für die
-									Erreichung des Zweckes der Erhebung nicht mehr erforderlich
-									sind.
-								</td>
-							</tr>
-						</table>
-					</div>
-				</div>
-			</article>
+		<section id="challenges">
+			<h2>12 Challenges und Code-Ausf├╝hrung</h2>
+			<p>
+				Bei Programmier-Challenges verarbeiten wir die von Ihnen eingereichten Codes, Test- und Bewertungsdaten,
+				Logs der Code-Ausf├╝hrung sowie Zeit- und Ergebnisdaten. Die Verarbeitung erfolgt zur Vertragserf├╝llung
+				(Art. 6 Abs. 1 lit. b DSGVO) und zur Betrugsvermeidung (Art. 6 Abs. 1 lit. f DSGVO). Code-Ausf├╝hrungen
+				erfolgen in unserem Sandkasten-Dienst innerhalb der EU. Rohdaten werden in der Regel nach 30 Tagen
+				automatisch gel├Âscht; Ergebnis- und Punkteinformationen verbleiben in Ihrem Konto, bis Sie dieses l├Âschen.
+			</p>
 		</section>
 
-		<section id="Kontaktmöglichkeiten">
-			<h2>6 Kontaktmöglichkeiten</h2>
-			<article>
-				<h3>6.1 Allgemeine Informationen</h3>
-				<p>
-					Über unsere Website haben Sie die Möglichkeit per E-Mail, über unser
-					Formular oder zur Terminvereinbarung Kontakt mit uns aufzunehmen.
-				</p>
-				<p>
-					Im Rahmen der Kontaktaufnahme und Beantwortung Ihrer Anfrage
-					verarbeiten wir folgende personenbezogene Daten von Ihnen:
-				</p>
-				<ul>
-					<li>Name</li>
-					<li>E-Mail</li>
-					<li>Datum und Zeit der Anfrage</li>
-					<li>IP-Adresse</li>
-					<li>
-						Weitere personenbezogene Daten, die Sie uns im Rahmen der
-						Kontaktaufnahme mitteilen.
-					</li>
-				</ul>
-			</article>
-
-			<article>
-				<h3>6.2 Zweck der Verarbeitung</h3>
-				<p>
-					Wir verarbeiten Ihre Daten zur Beantwortung Ihrer Anfrage sowie andere
-					daraus resultierende Sachverhalte.
-				</p>
-			</article>
-
-			<article>
-				<h3>6.3 Rechtsgrundlage</h3>
-				<p>
-					Wenn Ihre Anfrage im Zusammenhang mit vorvertraglichen Maßnahmen oder
-					mit einem bestehenden Vertrag mit uns beruht, ist die Rechtsgrundlage
-					die Vertragserfüllung und Durchführung vorvertraglicher Maßnahmen gem.
-					Art. 6 Abs. 1 S. 1 lit. b. DSGVO.
-				</p>
-				<p>
-					Wenn Ihre Anfrage unabhängig von vertraglichen oder vorvertraglichen
-					Maßnahmen erfolgt, stellen unsere überwiegenden berechtigten
-					Interessen gem. Art. 6 Abs. 1 S. 1 lit. f DSGVO die Rechtsgrundlage
-					dar. Das überwiegende berechtigte Interesse entspricht den oben
-					genannten Zwecken.
-				</p>
-			</article>
-
-			<article>
-				<h3>6.4 Speicherdauer</h3>
-				<p>
-					Wir löschen Ihre personenbezogenen Daten, sobald sie für die
-					Erreichung des Zweckes der Erhebung nicht mehr erforderlich sind. Im
-					Rahmen von Kontaktanfragen ist dies grundsätzlich dann der Fall, wenn
-					sich aus den Umständen ergibt, dass der konkrete Sachverhalt
-					abschließend bearbeitet ist.
-				</p>
-			</article>
-
-			<article>
-				<h3>6.5 Empfänger personenbezogener Daten</h3>
-				<div class="overflow-x-auto">
-					<table>
-						<tr>
-							<th>Dienst</th>
-							<th>Anbieter</th>
-							<th>Zweck</th>
-							<th>Rechtsgrundlage</th>
-							<th>Datenschutzhinweis</th>
-						</tr>
-						<tr>
-							<td>Calendly</td>
-							<td>
-								Calendly LLC, 3423 Piedmont Road NE, Atlanta, GA 30305-1754, USA
-							</td>
-							<td>Kommunikation und Terminvereinbarung</td>
-							<td>
-								Ihre Einwilligung gem. Art. 6 Abs. 1 S. 1 lit. a DSGVO;
-								Vertragserfüllung und Durchführung vorvertraglicher Maßnahmen gem.
-								Art. 6 Abs. 1 S. 1 lit. b. DSGVO
-							</td>
-							<td>
-								<a href="https://calendly.com/pages/privacy" target="_blank">
-									https://calendly.com/pages/privacy
-								</a>
-							</td>
-						</tr>
-					</table>
-				</div>
-			</article>
+		<section id="jobs">
+			<h2>13 Jobs und Karriereangebote</h2>
+			<p>
+				├£ber den Jobs-Microservice k├Ânnen Unternehmen Stellen ver├Âffentlichen und Bewerbende sich informieren oder
+				bewerben. Wir verarbeiten dabei Kontaktdaten der Unternehmensansprechpartner, Stelleninhalte sowie ÔÇô bei
+				Bewerbungen ÔÇô die von Ihnen bereitgestellten Unterlagen (Lebenslauf, Motivationsschreiben, Referenzen).
+				Bewerbungsdaten speichern wir nach Abschluss des Prozesses sechs Monate zur Rechtsverteidigung (Art. 6 Abs. 1
+				lit. b DSGVO, ┬º 26 Abs. 1 BDSG). Mit Ihrer Einwilligung speichern wir Unterlagen l├ñnger f├╝r einen Talentpool.
+				Eine Weitergabe an die ausschreibenden Unternehmen erfolgt nur zur Bearbeitung Ihrer Bewerbung.
+			</p>
 		</section>
 
-		<section id="Newsletter">
-			<h2>7 Newsletter</h2>
-
-			<article>
-				<h3>7.1 Allgemeine Informationen</h3>
-				<p>
-					Wir bieten Ihnen die Möglichkeit, den Newsletter unseres Unternehmens
-					zu erhalten. Mit unserem Newsletter informieren wir Kunden und
-					Geschäftspartner in regelmäßigen Abständen über unsere Angebote.
-				</p>
-				<p>
-					Im Rahmen des Newsletterversands verarbeiten wir folgende
-					personenbezogene Daten:
-				</p>
-				<ul>
-					<li>E-Mail-Adresse</li>
-					<li>Vor- und Nachname</li>
-					<li>Organisation</li>
-					<li>Bevorzugte Sprache</li>
-					<li>
-						Metadaten (z. B. Geräteinformationen, IP-Adresse, Datum- und Uhrzeit
-						der Anmeldung)
-					</li>
-				</ul>
-
-				<div>
-					<h4>7.1.1 Newsletteranmeldung</h4>
-					<p>
-						Wenn Sie sich über unsere Website für den Newsletter anmelden,
-						senden wir an die von Ihnen erstmalig für den Newsletterversand
-						eingetragene E-Mail-Adresse eine Bestätigungsmail im
-						Double-Opt-In-Verfahren. Diese Bestätigungsmail dient der
-						Überprüfung, ob Sie als Inhaber der E-Mail-Adresse den Empfang des
-						Newsletters autorisiert haben. Dabei wird die Anmeldung zum
-						Newsletter protokolliert.
-					</p>
-				</div>
-
-				<div>
-					<h4>7.1.2 Newsletterversand an Bestandskunden</h4>
-					<p>
-						Wenn Sie uns Ihre E-Mail-Adresse beim Kauf von Waren oder
-						Dienstleistungen zur Verfügung gestellt haben, behalten wir uns vor,
-						Ihnen regelmäßig Angebote zu ähnlichen Waren oder Dienstleistungen,
-						wie den bereits gekauften, aus unserem Sortiment per E-Mail
-						zuzusenden. Hierfür müssen wir gem. § 7 Abs. 3 UWG keine gesonderte
-						Einwilligung von Ihnen einholen.
-					</p>
-				</div>
-
-				<div>
-					<h4>7.1.3 Newsletter-Tracking</h4>
-					<p>
-						Unsere Newsletter enthalten sog. Zählpixel. Dabei handelt es sich um
-						eine Miniaturgrafik, die in E-Mails eingebettet wird. So können wir
-						z. B. nachvollziehen, ob und wann eine E-Mail von Ihnen geöffnet
-						wurde und welche in der E-Mail befindlichen Links von Ihnen
-						aufgerufen wurden. Dadurch sind wir in der Lage, Erfolg oder
-						Misserfolg von Online-Marketing-Kampagnen statistisch auszuwerten.
-						Die durch die Zählpixel erhobenen personenbezogenen Daten, werden
-						von uns gespeichert und ausgewertet, um den Newsletterversand zu
-						optimieren und den Inhalt zukünftiger Newsletter noch besser Ihren
-						Interessen anzupassen.
-					</p>
-				</div>
-			</article>
-
-			<article>
-				<h3>7.2 Zweck der Verarbeitung</h3>
-				<p>Wir verarbeiten Ihre personenbezogenen Daten für folgende Zwecke:</p>
-				<ul>
-					<li>Newsletterversand: Durchführung von Marketingmaßnahmen.</li>
-					<li>
-						Double-Opt-In-Verfahren: Erfüllung unserer gesetzlichen
-						Nachweispflichten.
-					</li>
-					<li>
-						Newsletter-Tracking: Einblendung personalisierter Werbung,
-						Marktforschung, Erfolgsmessung.
-					</li>
-				</ul>
-			</article>
-
-			<article>
-				<h3>7.3 Rechtsgrundlage</h3>
-				<p>
-					Die Rechtsgrundlage für die Verarbeitung Ihrer personenbezogenen Daten
-					im Rahmen des:
-				</p>
-				<ul>
-					<li>
-						Newsletter-Abonnements ist Ihre Einwilligung gem. Art. 6 Abs. 1 S. 1
-						lit. a DSGVO,
-					</li>
-					<li>
-						Newsletter-Versands an Bestandskunden ist unser berechtigtes
-						Interesse Art. 6 Abs. 1 S. 1 lit. f DSGVO,
-					</li>
-					<li>
-						sowie Newsletter-Trackings ist Ihre Einwilligung gem. Art. 6 Abs. 1
-						S. 1 lit. a DSGVO.
-					</li>
-				</ul>
-			</article>
-
-			<article>
-				<h3>7.4 Speicherdauer</h3>
-				<p>
-					Wir löschen Ihre personenbezogenen Daten, sobald sie für die
-					Erreichung des Zweckes der Erhebung nicht mehr erforderlich sind. Im
-					Rahmen des Newslettersversand ist dies grundsätzlich dann der Fall,
-					wenn Sie Ihre Einwilligung widerrufen oder Sie der Verarbeitung
-					widersprechen.
-				</p>
-				<p>
-					In jedem Newsletter befindet sich daher ein entsprechender
-					Opt-Out-Link. Zusätzlich besteht die Möglichkeit, sich jederzeit auch
-					auf unserer Internetseite vom Newsletterversand abzumelden oder uns
-					dies auf andere Weise mitzuteilen. Eine Abmeldung vom Erhalt des
-					Newsletters deuten wir automatisch als Widerruf oder Widerruf.
-				</p>
-			</article>
+		<section id="events">
+			<h2>14 Events, Webinare und Community-Aktivit├ñten</h2>
+			<p>
+				F├╝r Events, Coachings und Community-Angebote verarbeiten wir Registrierungsdaten (Name, E-Mail, Status),
+				Teilnahmen, Feedback, Kalenderdaten (iCal) sowie ggf. Informationen zu vergebenen XP. Rechtsgrundlage ist
+				Art. 6 Abs. 1 lit. b DSGVO; Feedbackauswertungen erfolgen auf Basis unseres berechtigten Interesses
+				(Art. 6 Abs. 1 lit. f DSGVO). Eventdaten werden 12 Monate nach Durchf├╝hrung gel├Âscht, sofern keine gesetzlichen
+				Pflichten entgegenstehen.
+			</p>
 		</section>
 
-		<section id="Zahlungsdienstleister">
-			<h2>8 Zahlungsdienstleister</h2>
-			<article>
-				<h3>Allgemeine Informationen</h3>
-				<p>
-					Wir bieten Ihnen die Gelegenheit, verschiedene Zahlungsmöglichkeiten
-					zu nutzen. Dabei setzen wir Banken, Kreditinstitute sowie weitere
-					Zahlungsdienstleister ein, die personenbezogenen Daten von Ihnen
-					verarbeiten. Die konkreten personenbezogenen Daten werden nur durch
-					den entsprechenden Zahlungsdienstleister verarbeitet. Wir erhalten als
-					Information nur, ob eine Zahlung erfolgt ist (Bestätigung oder
-					Negativauskunft), jedoch keine Konto- oder Kreditkartendaten. Es
-					besteht die Möglichkeit, dass der jeweils von uns eingesetzte
-					Zahlungsdienstleister Ihre personenbezogenen Daten an
-					Wirtschaftsauskunfteien übermittelt, um eine Identitäts- und
-					Bonitätsprüfung durchzuführen. Beachten Sie ebenfalls die
-					Geschäftsbedingungen und Datenschutzhinweise der jeweiligen
-					Zahlungsdienstleister.
-				</p>
-			</article>
-
-			<article>
-				<h3>Verarbeitete Daten</h3>
-				<ul>
-					<li>Bestandsdaten (z. B. Vor- und Nachname, Adresse),</li>
-					<li>
-						Zahlungsdaten (z. B. Bankverbindung, Rechnungen, Zahlungshistorie),
-					</li>
-					<li>Kontaktdaten (z. B. E-Mail-Adresse, Telefonnummer),</li>
-					<li>Vertragsdaten (z. B. Vertragsgegenstand, Vertragslaufzeit),</li>
-					<li>
-						Nutzungsdaten (z. B. besuchte Webseiten, Zeitpunkt von Zugriffen),
-					</li>
-					<li>Meta- und Kommunikationsdaten (z. B. IP-Adresse).</li>
-					<li>
-						Inhaltsdaten (z. B. eingegebene Textinhalte, Lichtbilder, Videos).
-					</li>
-				</ul>
-			</article>
-
-			<article>
-				<h3>Zweck der Verarbeitung</h3>
-				<ul>
-					<li>Anbieten vertraglicher Leistungen und Service</li>
-					<li>
-						Tracking (z. B. interessens- und verhaltensbezogenes Profiling)
-					</li>
-					<li>Feedback (z. B. Sammeln von Feedback via Online-Formular)</li>
-					<li>Affiliate-Nachverfolgung</li>
-				</ul>
-			</article>
-
-			<article>
-				<h3>Rechtsgrundlage</h3>
-				<ul>
-					<li>
-						Vertragserfüllung und Durchführung vorvertraglicher Maßnahmen (Art.
-						6 Abs. 1 S. 1 lit. b. DSGVO)
-					</li>
-					<li>Einwilligung (Art. 6 Abs. 1 S. 1 lit. a DSGVO).</li>
-					<li>
-						Berechtigte Interessen (Art. 6 Abs. 1 S. 1 lit. f. DSGVO). Falls die
-						Datenverarbeitung nicht aufgrund der Vertragserfüllung oder
-						Durchführung vorvertraglicher Maßnahmen oder Ihrer Einwilligung
-						erfolgt, stellt unser berechtigtes Interesse die Rechtsgrundlage
-						dar. Das berechtigte Interesse entspricht den oben genannten
-						Zwecken.
-					</li>
-				</ul>
-			</article>
-
-			<article>
-				<h3>2. Anbieter</h3>
-			</article>
-
-			<article>
-				<h3>Paypal</h3>
-				<p>
-					PayPal (Europe) S.à r.l. et Cie, S.C.A., 22-24 Boulevard Royal, L-2449
-					Luxembourg (PayPal).
-				</p>
-			</article>
-
-			<article>
-				<h3>Datenschutz außerhalb der EU und des EWR</h3>
-				<p>Wir haben mit PayPal Standarddatenschutzklauseln vereinbart.</p>
-				<p>
-					Zusätzlich hat PayPal für den konzerninternen Datenaustausch Binding
-					Corporate Rules implementiert.
-				</p>
-				<p>
-					<a href="https://www.paypal.com/us/webapps/mpp/gdpr-readiness-requirements" target="_blank">
-						https://www.paypal.com/us/webapps/mpp/gdpr-readiness-requirements
-					</a>
-				</p>
-			</article>
-
-			<article>
-				<h3>Datenschutzerklärung</h3>
-				<p>
-					Weitere Informationen zur Datenverarbeitung finden Sie in der
-					Datenschutzerklärung von PayPal.
-					<a href="https://www.paypal.com/de/webapps/mpp/ua/privacy-full" target="_blank">
-						https://www.paypal.com/de/webapps/mpp/ua/privacy-full
-					</a>
-				</p>
-			</article>
-
-			<article>
-				<h3>Stripe</h3>
-			</article>
-
-			<article>
-				<h3>Anbieter</h3>
-				<p>
-					Stripe, Inc., 510 Townsend Street, San Francisco, CA 94103, USA
-					(Stripe).
-				</p>
-			</article>
-
-			<article>
-				<h3>Beschreibung</h3>
-				<p>
-					Stripe ist ein Online-Bezahldienst. Das Unternehmen verwendet dabei
-					ein selbstlernendes Betrugs-Präventions-System.
-					<em>Datenschutz außerhalb der EU und des EWR</em>
-					Wir haben mit Stripe Standarddatenschutzklauseln implementiert.
-				</p>
-			</article>
-
-			<article>
-				<h3>Datenschutzerklärung</h3>
-				<p>
-					Weitere Informationen zur Datenverarbeitung finden Sie in der
-					Datenschutzerklärung von Stripe:
-					<a href="https://stripe.com/de/privacy" target="_blank">
-						https://stripe.com/de/privacy
-					</a>
-				</p>
-			</article>
+		<section id="zahlungen">
+			<h2>15 Zahlungsabwicklung</h2>
+			<p>
+				Premium-Mitgliedschaften und kostenpflichtige Events werden ├╝ber PayPal abgewickelt. Wir erhalten von PayPal
+				Transaktionskennungen, Zahlstatus und ÔÇô sofern ├╝bermittelt ÔÇô die Rechnungsadresse. Die Verarbeitung ist zur
+				Vertragserf├╝llung (Art. 6 Abs. 1 lit. b DSGVO) und zur Erf├╝llung steuerrechtlicher Pflichten
+				(Art. 6 Abs. 1 lit. c DSGVO) erforderlich. Nach Handels- und Steuerrecht bewahren wir Rechnungsunterlagen
+				zehn Jahre auf. Zahlungen werden ├╝ber PayPal (Europe) S.├á r.l. et Cie S.C.A. mit Sitz in Luxemburg abgewickelt.
+			</p>
 		</section>
 
-		<section id="SozialeNetzwerke">
-			<h2>9 Soziale Netzwerke</h2>
-
-			<article>
-				<h3>9.1 Allgemeine Informationen</h3>
-				<p>
-					Wir unterhalten Präsenzen in sozialen Netzwerken, um mit Ihnen
-					kommunizieren und über unsere Leistungen informieren zu können.
-				</p>
-			</article>
-
-			<article>
-				<h3>9.2 Zweck der Verarbeitung</h3>
-				<p>
-					Der Zweck der Verarbeitung ist die Unterhaltung von Präsenzen in
-					sozialen Medien.
-				</p>
-			</article>
-
-			<article>
-				<h3>9.3 Rechtsgrundlage</h3>
-				<p>
-					Die Rechtsgrundlage für die Verarbeitung personenbezogener Daten ist
-					unser überwiegendes berechtigtes Interesse gemäß Art. 6 Abs. 1 S. 1
-					lit. f DSGVO. Das überwiegende berechtigte Interesse entspricht den
-					oben genannten Zwecken.
-				</p>
-			</article>
-
-			<article>
-				<h3>9.4 Empfänger personenbezogener Daten</h3>
-				<p>Wir unterhalten Präsenzen in folgenden sozialen Medien:</p>
-				<div class="overflow-x-auto">
-					<table>
-						<tr>
-							<th>Soziales Netzwerk</th>
-							<th>Anbieter</th>
-							<th>Rechtsgrundlage</th>
-							<th>Weitere Informationen</th>
-						</tr>
-						<tr>
-							<td>LinkedIn</td>
-							<td>
-								LinkedIn Ireland Unlimited Company Wilton Place, Dublin 2, Irland
-							</td>
-							<td>Berechtigte Interessen gem. Art. 6 Abs. 1 S. 1 lit. f DSGVO</td>
-							<td>
-								<a href="https://de.linkedin.com/legal/privacy-policy?src=or-search&veh=www.google.com%7Cor-search "
-									target="_blank">
-									Datenschutzerklärung
-								</a>
-								<a href="https://www.linkedin.com/psettings/guest-controls/retargeting-opt-out" target="_blank">
-									Opt-out und Werbeeinstellungen
-								</a>
-								<a href="https://legal.linkedin.com/pages-joint-controller-addendum" target="_blank">
-									Vertrag zur gemeinsamen Verantwortlichkeit
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>Twitter</td>
-							<td>
-								Twitter International Company, One Cumberland Place, Fenian
-								Street, Dublin 2, Irland
-							</td>
-							<td>Berechtigte Interessen gem. Art. 6 Abs. 1 S. 1 lit. f DSGVO</td>
-							<td>
-								<a href="https://twitter.com/de/privacy" target="_blank">
-									Datenschutzerklärung
-								</a>
-								<a href="https://twitter.com/settings/account/personalization" target="_blank">
-									Widerspruchseinstellungen
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>Facebook</td>
-							<td>
-								Facebook Ireland Ltd., 4 Grand Canal Square, Grand Canal Harbour,
-								Dublin 2, Irland
-							</td>
-							<td>Berechtigte Interessen gem. Art. 6 Abs. 1 S. 1 lit. f DSGVO</td>
-							<td>
-								<a href="https://www.facebook.com/privacy/policy/?entry_point=data_policy_redirect&entry=0"
-									target="_blank">
-									Datenschutzerklärung
-								</a>
-								<a href="https://www.facebook.com/settings?tab=ads" target="_blank">
-									Widerspruchseinstellungen
-								</a>
-								<a href="https://de-de.facebook.com/legal/terms/page_controller_addendum" target="_blank">
-									Vertrag zur gemeinsamen Verantwortlichkeit
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>Instagram</td>
-							<td>
-								Facebook Ireland Ltd., 4 Grand Canal Square, Grand Canal Harbour,
-								Dublin 2, Irland
-							</td>
-							<td>Berechtigte Interessen gem. Art. 6 Abs. 1 S. 1 lit. f DSGVO</td>
-							<td>
-								<a href="https://privacycenter.instagram.com/policy/?entry_point=ig_help_center_data_policy_redirect"
-									target="_blank">
-									Datenschutzerklärung
-								</a>
-								<a href="https://privacycenter.instagram.com/policy/?entry_point=ig_help_center_data_policy_redirect"
-									target="_blank">
-									Widerspruchseinstellungen
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>Xing</td>
-							<td>Xing AG, Dammtorstraße 29-32, 20354 Hamburg</td>
-							<td>Berechtigte Interessen gem. Art. 6 Abs. 1 S. 1 lit. f DSGVO</td>
-							<td>
-								<a href="https://privacy.xing.com/de/datenschutzerklaerung" target="_blank">
-									Datenschutzerklärung
-								</a>
-								<a href="https://privacy.xing.com/de/datenschutzerklaerung" target="_blank">
-									Widerspruchseinstellungen
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>Youtube</td>
-							<td>
-								Google Ireland Limited, Gordon House, Barrow Street, Dublin 4,
-								Irland
-							</td>
-							<td>Berechtigte Interessen gem. Art. 6 Abs. 1 S. 1 lit. f DSGVO</td>
-							<td>
-								<a href="https://policies.google.com/privacy" target="_blank">
-									Datenschutzerklärung
-								</a>
-								<a href="https://adssettings.google.com/authenticated" target="_blank">
-									Widerspruchseinstellungen
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>LinkedIn</td>
-							<td>
-								LinkedIn Ireland Unlimited Company Wilton Place, Dublin 2, Irland
-							</td>
-							<td>Art. 6 Abs. 1 S. 1 lit. f DSGVO</td>
-							<td>
-								<a href="https://de.linkedin.com/legal/privacy-policy?src=or-search&veh=www.google.com%7Cor-search"
-									target="_blank">
-									Datenschutzerklärung
-								</a>
-								<a href="https://www.linkedin.com/psettings/guest-controls/retargeting-opt-out" target="_blank">
-									Opt-out und Werbeeinstellungen
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>Twitter</td>
-							<td>
-								Twitter International Company, One Cumberland Place, Fenian
-								Street, Dublin 2, Irland
-							</td>
-							<td>Art. 6 Abs. 1 S. 1 lit. f DSGVO</td>
-							<td>
-								<a href="https://twitter.com/de/privacy" target="_blank">
-									Datenschutzerklärung
-								</a>
-								<a href="https://twitter.com/settings/account/personalization" target="_blank">
-									Widerspruchseinstellungen
-								</a>
-							</td>
-						</tr>
-					</table>
-				</div>
-			</article>
+		<section id="newsletter">
+			<h2>16 Newsletter und Produktinformationen</h2>
+			<p>
+				Mit Ihrer Einwilligung senden wir Newsletter, Produkt- und Eventupdates. Wir verwenden das
+				Double-Opt-In-Verfahren und protokollieren Anmeldung, Best├ñtigung, Zeitstempel und IP-Adresse zum Nachweis
+				(Art. 6 Abs. 1 lit. a DSGVO, ┬º 7 UWG). Sie k├Ânnen Ihre Einwilligung jederzeit ├╝ber den Abmeldelink oder per
+				E-Mail an hallo@bootstrap.academy widerrufen. Nach Abmeldung speichern wir Ihre E-Mail-Adresse bis zu drei
+				Jahre in einer Sperrliste, um den Widerruf nachweisen zu k├Ânnen.
+			</p>
 		</section>
 
-		<section id="IhreRechte">
-			<h2>10 Ihre Rechte</h2>
-
-			<article>
-				<h3>10.1 Recht auf Bestätigung</h3>
-				<p>
-					Sie haben das Recht, von uns eine Bestätigung darüber zu verlangen, ob
-					Sie betreffende personenbezogene Daten verarbeitet werden.
-				</p>
-			</article>
-
-			<article>
-				<h3>10.2 Auskunft (Art. 15 DSGVO)</h3>
-				<p>
-					Sie haben das Recht, jederzeit von uns unentgeltliche Auskunft über
-					die zu Ihrer Person gespeicherten personenbezogenen Daten sowie eine
-					Kopie dieser Daten nach Maßgabe der gesetzlichen Bestimmungen zu
-					erhalten.
-				</p>
-			</article>
-
-			<article>
-				<h3>10.3 Berichtigung (Art. 16 DSGVO)</h3>
-				<p>
-					Sie haben das Recht, die Berichtigung Sie betreffender unrichtiger
-					personenbezogener Daten zu verlangen. Ferner steht Ihnen das Recht zu,
-					unter Berücksichtigung der Zwecke der Verarbeitung, die
-					Vervollständigung unvollständiger personenbezogener Daten zu
-					verlangen.
-				</p>
-			</article>
-
-			<article>
-				<h3>10.4 Löschung (Art. 17 DSGVO)</h3>
-				<p>
-					Sie haben das Recht, von uns zu verlangen, dass personenbezogenen
-					Daten, die sie betreffen, unverzüglich gelöscht werden, wenn einer der
-					gesetzlich vorgesehenen Gründe zutrifft und soweit die Verarbeitung
-					bzw. Speicherung nicht erforderlich ist.
-				</p>
-			</article>
-
-			<article>
-				<h3>10.5 Einschränkung der Verarbeitung (Art. 18 DSGVO)</h3>
-				<p>
-					Sie haben das Recht, von uns die Einschränkung der Verarbeitung zu
-					verlangen, wenn eine der gesetzlichen Voraussetzungen gegeben ist.
-				</p>
-			</article>
-
-			<article>
-				<h3>10.6 Datenübertragbarkeit (Art. 20 DSGVO)</h3>
-				<p>
-					Sie haben das Recht, die Sie betreffenden personenbezogenen Daten, die
-					Sie uns bereitgestellt haben, in einem strukturierten, gängigen und
-					maschinenlesbaren Format zu erhalten. Weiterhin haben Sie das Recht,
-					diese Daten einem anderen Verantwortlichen ohne Behinderung durch uns,
-					dem die personenbezogenen Daten bereitgestellt wurden, zu übermitteln,
-					sofern die Verarbeitung auf der Einwilligung gem. Art. 6 Abs. 1 S. 1
-					lit. a DSGVO oder Art. 9 Abs. 2 lit. a DSGVO oder auf einem Vertrag
-					gem. Art. 6 Abs. 1 S. 1 lit. b DSGVO beruht und die Verarbeitung
-					mithilfe automatisierter Verfahren erfolgt, sofern die Verarbeitung
-					nicht für die Wahrnehmung einer Aufgabe erforderlich ist, die im
-					öffentlichen Interesse liegt oder in Ausübung öffentlicher Gewalt
-					erfolgt, welche uns übertragen wurde.
-				</p>
-				<p>
-					Zudem haben Sie bei der Ausübung Ihres Rechts auf Datenübertragbarkeit
-					gem. Art. 20 Abs. 1 DSGVO das Recht, zu erwirken, dass die
-					personenbezogenen Daten direkt von einem Verantwortlichen an einen
-					anderen Verantwortlichen übermittelt werden, soweit dies technisch
-					machbar ist und sofern hiervon nicht die Rechte und Freiheiten anderer
-					Personen beeinträchtigt werden.
-				</p>
-			</article>
-
-			<article>
-				<h3>10.7 Widerspruch (Art. 21 DSGVO)</h3>
-				<p>
-					<em>
-						Sie haben das Recht, aus Gründen, die sich aus Ihrer besonderen
-						Situation ergeben, jederzeit gegen die Verarbeitung Sie betreffender
-						personenbezogener Daten, die aufgrund einer Datenverarbeitung im
-						öffentlichen Interesse gem. Art. 6 Abs. 1 S. 1 lit. e DSGVO oder auf
-						Grundlage unseres berechtigten Interesses gem. Art. 6 Abs. 1 S. 1
-						lit. f DSGVO erfolgt, Widerspruch einzulegen.
-					</em>
-				</p>
-				<p>
-					Dies gilt auch für ein auf diese Bestimmungen gestütztes Profiling im
-					Sinne von Art. 4 Nr. 4 DSGVO.
-				</p>
-				<p>
-					Legen Sie Widerspruch ein, werden wir Ihre personenbezogenen Daten
-					nicht mehr verarbeiten, es sei denn, wir können zwingende berechtigte
-					Gründe für die Verarbeitung nachweisen, die Ihre Interessen, Rechte
-					und Freiheiten überwiegen, oder die Verarbeitung dient der
-					Geltendmachung, Ausübung oder Verteidigung von Rechtsansprüchen.
-				</p>
-				<p>
-					In Einzelfällen verarbeiten wir personenbezogene Daten, um
-					Direktwerbung zu betreiben. Sie können jederzeit Widerspruch gegen die
-					Verarbeitung der personenbezogenen Daten zum Zwecke derartiger Werbung
-					einlegen. Dies gilt auch für das Profiling, soweit es mit solcher
-					Direktwerbung in Verbindung steht. Widersprechen Sie gegenüber uns der
-					Verarbeitung für Zwecke der Direktwerbung, so werden wir die
-					personenbezogenen Daten nicht mehr für diese Zwecke verarbeiten.
-				</p>
-				<p>
-					Zudem haben Sie das Recht, aus Gründen, die sich aus Ihrer besonderen
-					Situation ergeben, gegen die Sie betreffende Verarbeitung
-					personenbezogener Daten, die bei uns zu wissenschaftlichen oder
-					historischen Forschungszwecken oder zu statistischen Zwecken gem. Art.
-					89 Abs. 1 DSGVO erfolgen, Widerspruch einzulegen, es sei denn, eine
-					solche Verarbeitung ist zur Erfüllung einer im öffentlichen Interesse
-					liegenden Aufgabe erforderlich.
-				</p>
-			</article>
-
-			<article>
-				<h3>10.8 Widerruf einer datenschutzrechtlichen Einwilligung</h3>
-				<p>
-					Sie haben das Recht, Ihre Einwilligung zur Verarbeitung
-					personenbezogener Daten jederzeit mit Wirkung für die Zukunft zu
-					widerrufen.
-				</p>
-			</article>
-
-			<article>
-				<h3>10.9 Beschwerde bei einer Aufsichtsbehörde</h3>
-				<p>
-					Sie haben das Recht, sich bei einer für Datenschutz zuständigen
-					Aufsichtsbehörde über unsere Verarbeitung personenbezogener Daten zu
-					beschweren.
-				</p>
-			</article>
+		<section id="kommunikation">
+			<h2>17 Kontakt, Support und Kommunikation</h2>
+			<p>
+				Wenn Sie uns kontaktieren (z.&nbsp;B. per E-Mail, Formular, Community-Kan├ñle), verarbeiten wir Ihre Angaben
+				zur Bearbeitung der Anfrage und f├╝r R├╝ckfragen. Rechtsgrundlage ist Art. 6 Abs. 1 lit. b DSGVO, bei allgemeinen
+				Anfragen Art. 6 Abs. 1 lit. f DSGVO. Kommunikationsdaten speichern wir bis zu drei Jahre nach Abschluss zur
+				Verteidigung m├Âglicher Rechtsanspr├╝che.
+			</p>
 		</section>
 
-		<section id="AktualitätUndÄnderungenDerDatenschutzhinweise">
-			<article>
-				<h2>11 Aktualität und Änderungen der Datenschutzhinweise</h2>
-				<p>
-					Diese Datenschutzhinweise sind aktuell gültig und hat den folgenden
-					Stand: Oktober 2022.
-				</p>
-				<p>
-					Wenn wir unsere Website und unsere Angebote weiterentwickeln oder sich
-					gesetzliche oder behördliche Vorgaben ändern, kann es notwendig sein,
-					diese Datenschutzhinweise zu ändern. Die jeweils aktuellen
-					Datenschutzhinweise können Sie jederzeit hier abrufen.
-				</p>
-			</article>
+		<section id="analyse">
+			<h2>18 Analyse und Produktentwicklung</h2>
+			<p>
+				Wir setzen keine Drittanbieter-Trackingdienste ein. Zur Weiterentwicklung der Plattform werten wir
+				pseudonymisierte Nutzungskennzahlen (z.&nbsp;B. aktive Nutzer:innen, Kursabschl├╝sse, Feature-Nutzung) und
+				Fehlerberichte auf unseren eigenen Systemen aus. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO. Sie k├Ânnen
+				dieser Verarbeitung widersprechen, wenn Gr├╝nde vorliegen, die sich aus Ihrer besonderen Situation ergeben.
+			</p>
+		</section>
+
+		<section id="botschutz">
+			<h2>19 Bot- und Missbrauchsschutz</h2>
+			<p>
+				Wir verwenden Google reCAPTCHA nur, wenn es f├╝r Formulare und Login-Schutz erforderlich ist. Hierbei k├Ânnen
+				Ihre IP-Adresse und weitere technische Informationen an Google LLC (USA) ├╝bermittelt werden. Rechtsgrundlagen
+				sind Art. 6 Abs. 1 lit. f DSGVO (Schutz vor Missbrauch) sowie bei aktiver Nutzung Ihre Einwilligung
+				(Art. 6 Abs. 1 lit. a DSGVO). Google nutzt Standardvertragsklauseln; weitere Informationen finden Sie in den
+				Datenschutzhinweisen von Google.
+			</p>
+		</section>
+
+		<section id="drittland">
+			<h2>20 Drittland├╝bermittlungen und Garantien</h2>
+			<p>
+				Einige Dienste (z.&nbsp;B. OAuth-Anbieter GitHub/Google/Discord, PayPal, Google reCAPTCHA) haben ihren Sitz
+				au├ƒerhalb des Europ├ñischen Wirtschaftsraums. F├╝r diese F├ñlle st├╝tzen wir Daten├╝bermittlungen auf
+				Standardvertragsklauseln der EU-Kommission und zus├ñtzliche Sicherheitsma├ƒnahmen. Weitere Informationen stellen
+				wir auf Anfrage gerne zur Verf├╝gung. Wenn eine Einwilligung erforderlich ist, informieren wir Sie gesondert.
+			</p>
+		</section>
+
+		<section id="speicherung">
+			<h2>21 Speicherdauer und L├Âschung</h2>
+			<p>
+				Wir verarbeiten und speichern personenbezogene Daten nur so lange, wie es f├╝r den jeweiligen Zweck oder
+				gesetzliche Aufbewahrungspflichten erforderlich ist. Nach Wegfall des Zwecks oder Ablauf gesetzlicher Fristen
+				l├Âschen oder anonymisieren wir die Daten. Konkret gelten u.&nbsp;a. folgende Fristen:
+			</p>
+			<ul>
+				<li>Konto- und Vertragsdaten: bis drei Jahre nach Vertragsende.</li>
+				<li>Abrechnungs- und Steuerunterlagen: zehn Jahre (┬º┬º 147 AO, 257 HGB).</li>
+				<li>Bewerbungsunterlagen: sechs Monate nach Abschluss (l├ñngere Aufbewahrung nur mit Einwilligung).</li>
+				<li>Support-Kommunikation: bis zu drei Jahre.</li>
+				<li>Server-Logs und Telemetrie: 14ÔÇô30 Tage.</li>
+			</ul>
+		</section>
+
+		<section id="pflichtangaben">
+			<h2>22 Pflichtangaben und Freiwilligkeit</h2>
+			<p>
+				Zur Registrierung sind Name, E-Mail-Adresse und ein Passwort erforderlich. Ohne diese Angaben k├Ânnen wir
+				Ihnen die Plattform nicht bereitstellen. Alle weiteren Angaben (z.&nbsp;B. Profilinfos, Newsletter,
+				Talentpool) sind freiwillig. Wenn wir weitere Angaben als Pflichtfelder erheben, markieren wir dies
+				gesondert.
+			</p>
+		</section>
+
+		<section id="rechte">
+			<h2>23 Ihre Datenschutzrechte</h2>
+			<p>Ihnen stehen die folgenden Rechte gem├ñ├ƒ Art. 15ÔÇô22 DSGVO zu:</p>
+			<ul>
+				<li>Auskunft ├╝ber die Verarbeitung Ihrer personenbezogenen Daten,</li>
+				<li>Berichtigung unrichtiger oder Vervollst├ñndigung unvollst├ñndiger Daten,</li>
+				<li>L├Âschung personenbezogener Daten (Recht auf Vergessenwerden),</li>
+				<li>Einschr├ñnkung der Verarbeitung,</li>
+				<li>Daten├╝bertragbarkeit,</li>
+				<li>Widerspruch gegen Verarbeitungen auf Grundlage von Art. 6 Abs. 1 lit. e oder lit. f DSGVO,</li>
+				<li>Widerruf erteilter Einwilligungen mit Wirkung f├╝r die Zukunft.</li>
+			</ul>
+			<p>
+				Bitte richten Sie Ihre Anliegen an
+				<a href="mailto:hallo@bootstrap.academy" class="underline-link">hallo@bootstrap.academy</a>
+				oder an unseren Datenschutzbeauftragten. Zur Bearbeitung Ihrer Anfrage k├Ânnen wir zus├ñtzliche Angaben zur
+				Identit├ñtspr├╝fung ben├Âtigen.
+			</p>
+		</section>
+
+		<section id="aufsicht">
+			<h2>24 Beschwerderecht bei Aufsichtsbeh├Ârden</h2>
+			<p>
+				Sie haben das Recht, sich bei einer Datenschutzaufsichtsbeh├Ârde zu beschweren, insbesondere in dem
+				Mitgliedstaat Ihres gew├Âhnlichen Aufenthaltsorts, Ihres Arbeitsplatzes oder des Orts des mutma├ƒlichen
+				Versto├ƒes (Art. 77 DSGVO). F├╝r uns zust├ñndig ist insbesondere das Bayerische Landesamt f├╝r Datenschutzaufsicht
+				(BayLDA), Promenade 27, 91522 Ansbach, Deutschland.
+			</p>
+		</section>
+
+		<section id="aenderungen">
+			<h2>25 ├änderungen dieser Hinweise</h2>
+			<p>
+				Wir passen diese Datenschutzhinweise an, sobald ├änderungen unserer Datenverarbeitung oder gesetzlicher
+				Vorgaben dies erforderlich machen. Die jeweils aktuelle Fassung ist jederzeit unter
+				<a
+					href="https://bootstrap.academy/docs/privacy"
+					target="_blank"
+					rel="noopener noreferrer"
+					>https://bootstrap.academy/docs/privacy</a
+				>
+				abrufbar.
+			</p>
+			<p><strong>Stand:</strong> Oktober 2025</p>
 		</section>
 	</main>
 </template>
@@ -994,7 +518,7 @@ export default {
     return {};
   },
   head: {
-    title: 'Privacy',
+    title: 'Datenschutz',
   },
 };
 </script>
@@ -1017,7 +541,8 @@ h4 {
 }
 
 table {
-	@apply mt-card;
+	@apply mt-card w-full;
+	border-collapse: collapse;
 }
 
 table th {
@@ -1025,7 +550,7 @@ table th {
 }
 
 table td {
-	@apply text-body-1 font-body text-body box;
+	@apply text-body-1 font-body text-body box align-top;
 }
 
 table,
@@ -1040,14 +565,6 @@ td a {
 
 section {
 	@apply mt-container;
-}
-
-article {
-	@apply mt-card;
-}
-
-div {
-	@apply mt-card;
 }
 
 p {


### PR DESCRIPTION
## Summary
- replace outdated privacy notice with microservice-aligned version covering backend, skills, jobs, events, challenges
- clarify cookie/storage usage, contact channels, third-country transfers, and update legal bases & retention table
- align page metadata/styling (title, tables) with new content and remove legacy contact/Calendly references

## Test Plan
- npm run generate