### PR TITLE
Fix docs link underline styling without invalid selectors

### DIFF
--- a/pages/docs/privacy.vue
+++ b/pages/docs/privacy.vue
@@ -641,11 +641,26 @@ ol li {
   @apply ml-10 list-decimal mt-box;
 }
 
-a:not(.table-content li a) {
-  @apply underline-link cursor-pointer;
+a {
+  @apply relative cursor-pointer pb-2;
+}
+
+a::after {
+  content: "";
+  position: absolute;
+  width: max(50%, 25px);
+  height: 1px;
+  background-color: var(--color-accent);
+  bottom: 0;
+  left: 0;
 }
 
 .table-content li a {
-  @apply block cursor-pointer mt-card-sm;
+  @apply block cursor-pointer pb-0 mt-card-sm;
+  position: static;
+}
+
+.table-content li a::after {
+  content: none;
 }
 </style>

--- a/pages/docs/right-of-withdrawal.vue
+++ b/pages/docs/right-of-withdrawal.vue
@@ -166,6 +166,16 @@ ul li {
 }
 
 a {
-  @apply underline-link cursor-pointer;
+  @apply relative cursor-pointer pb-2;
+}
+
+a::after {
+  content: "";
+  position: absolute;
+  width: max(50%, 25px);
+  height: 1px;
+  background-color: var(--color-accent);
+  bottom: 0;
+  left: 0;
 }
 </style>

--- a/pages/docs/terms-and-conditions.vue
+++ b/pages/docs/terms-and-conditions.vue
@@ -493,6 +493,16 @@ ul li {
   @apply ml-10 list-disc mt-box;
 }
 a {
-  @apply underline-link cursor-pointer;
+  @apply relative cursor-pointer pb-2;
+}
+
+a::after {
+  content: "";
+  position: absolute;
+  width: max(50%, 25px);
+  height: 1px;
+  background-color: var(--color-accent);
+  bottom: 0;
+  left: 0;
 }
 </style>


### PR DESCRIPTION
## Summary
- replace the scoped @apply underline-link usage with local anchor rules so Tailwind accepts the build
- recreate the decorative underline pseudo-element directly on anchors
- reset .table-content anchors to avoid the underline in the table of contents

## Test plan
- npm run lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
