### PR TITLE
Render a first-party default avatar

### DIFF
--- a/components/Avatar.vue
+++ b/components/Avatar.vue
@@ -1,0 +1,53 @@
+<template>
+  <svg
+    class="rounded-full bg-tertiary text-heading"
+    viewBox="0 0 40 40"
+    role="img"
+    :aria-label="label"
+  >
+    <text
+      v-if="initials"
+      x="20"
+      y="20"
+      text-anchor="middle"
+      dominant-baseline="central"
+      font-size="16"
+      font-weight="600"
+      fill="currentColor"
+    >
+      {{ initials }}
+    </text>
+  </svg>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { useI18n } from "vue-i18n";
+
+export default defineComponent({
+  props: {
+    // Display name the initials are taken from.
+    name: { type: String, default: "" },
+    // Already translated alt text; defaults to the generic user avatar label.
+    alt: { type: String, default: "" },
+  },
+  setup(props) {
+    const { t } = useI18n();
+
+    const initials = computed(() => {
+      const words = props.name.trim().split(/\s+/).filter(Boolean);
+      if (!words.length) return "";
+
+      const first = [...words[0]][0] ?? "";
+      const last = words.length > 1 ? ([...words[words.length - 1]][0] ?? "") : "";
+      return (first + last).toLocaleUpperCase();
+    });
+
+    const label = computed(() => props.alt || t("AltAttributes.UserAvatar"));
+
+    return { initials, label };
+  },
+});
+</script>
+
+<style scoped></style>

--- a/components/NavbarMenu.vue
+++ b/components/NavbarMenu.vue
@@ -14,11 +14,10 @@
         >
           <CheckBadgeIcon class="h-6 w-6 text-[#d4af37]" />
         </Tooltip>
-        <img
+        <Avatar
           @click="toggleMenu"
-          :src="image"
-          :alt="t('AltAttributes.UserAvatar')"
-          class="h-10 min-h-[2.5rem] w-10 min-w-[2.5rem] rounded-full object-cover"
+          :name="displayName"
+          class="h-10 min-h-[2.5rem] w-10 min-w-[2.5rem]"
         />
       </div>
     </div>
@@ -107,8 +106,8 @@ export default {
     }
 
     const user = useUser();
-    const image = computed(() => {
-      return user?.value?.avatar_url ?? "/images/about-2.webp";
+    const displayName = computed(() => {
+      return user?.value?.display_name ?? "";
     });
     return {
       links,
@@ -119,7 +118,7 @@ export default {
 
       isPremium,
       t,
-      image,
+      displayName,
       validTill,
     };
   },

--- a/components/calendar/Event.vue
+++ b/components/calendar/Event.vue
@@ -2,10 +2,10 @@
   <article class="border-l-4 bg-secondary p-4 style-card lg:style-box" :class="[theme.border]">
     <header class="mb-4 flex flex-wrap-reverse justify-between gap-y-2 gap-x-card">
       <div v-if="data.type == 'coaching'" class="flex gap-box">
-        <img
-          :src="data.instructor.avatar_url ?? '/images/about-2.webp'"
-          class="h-6 w-6 rounded-[50px] object-cover"
+        <Avatar
+          :name="data.instructor.display_name ?? data.instructor.name ?? ''"
           :alt="t('AltAttributes.EventInstructorAvatar')"
+          class="h-6 w-6 flex-shrink-0"
         />
 
         <h3 class="text-heading-4 capitalize">

--- a/components/calendar/EventSummary.vue
+++ b/components/calendar/EventSummary.vue
@@ -14,10 +14,10 @@
         <div class="flex items-center space-x-4">
           <Rating :rating="event.instructor_rating ?? 0" sm stars />
           <div class="flex items-center gap-2">
-            <img
-              :src="event.instructor.avatar_url ?? '/images/about-2.webp'"
-              class="h-6 w-6 rounded-[50px] object-cover"
+            <Avatar
+              :name="event.instructor.display_name ?? ''"
               :alt="t('AltAttributes.EventInstructorAvatar')"
+              class="h-6 w-6 flex-shrink-0"
             />
             <p>{{ event.instructor.display_name }}</p>
           </div>

--- a/components/form/Profile.vue
+++ b/components/form/Profile.vue
@@ -5,19 +5,7 @@
     @submit.prevent="onclickSubmitForm()"
     ref="refForm"
   >
-    <InputMedia class="mx-auto" id="image" rounded no-input v-model="image">
-      <template #hint="{ t }">
-        {{ t("Links.GravatarImage") }}
-        <a
-          href="https://de.gravatar.com/"
-          target="_blank"
-          :alt="t('AltAttributes.UserAvatar')"
-          class="cursor-pointer"
-        >
-          gravatar.com
-        </a>
-      </template>
-    </InputMedia>
+    <Avatar class="mx-auto h-40 w-40 flex-shrink-0" :name="form.display_name.value" />
 
     <Input
       :label="t('Inputs.Nickname')"
@@ -250,10 +238,6 @@ export default defineComponent({
     });
 
     // ============================================================= Setting Form
-    const image = computed(() => {
-      return props.data?.avatar_url ?? `/images/about-${getRandomNumber(1, 5)}.webp`;
-    });
-
     const hintNickname = computed(() => {
       let timestamp = props.data?.last_name_change ?? "";
       if (!!!timestamp) return "";
@@ -366,7 +350,6 @@ export default defineComponent({
       onclickSubmitForm,
       refForm,
       t,
-      image,
       hintNickname,
       business,
     };

--- a/components/form/WebinarRating.vue
+++ b/components/form/WebinarRating.vue
@@ -6,9 +6,9 @@
           {{ t("Headings.WebinarRating") }}
         </h6>
 
-        <img
-          class="h-14 w-14 flex-shrink-0 rounded-full object-cover mt-card md:h-16 md:w-16 lg:h-20 lg:w-20"
-          :src="instructor.avatar_url"
+        <Avatar
+          class="h-14 w-14 flex-shrink-0 mt-card md:h-16 md:w-16 lg:h-20 lg:w-20"
+          :name="instructor.display_name ?? ''"
           :alt="t('AltAttributes.EventInstructorAvatar')"
         />
         <h3 class="text-heading-3 mt-2 text-center">

--- a/components/leaderboard/TopUserCard.vue
+++ b/components/leaderboard/TopUserCard.vue
@@ -2,11 +2,7 @@
   <div
     class="relative flex w-[220px] max-w-[320px] flex-col items-center rounded-md border border-light px-6 py-10 transition-all duration-300 hover:-translate-y-2"
   >
-    <img
-      class="h-20 w-20 rounded-full object-cover"
-      :src="user?.user?.avatar_url ?? '/images/user1.jpg'"
-      :alt="t('AltAttributes.UserAvatar')"
-    />
+    <Avatar class="h-20 w-20 flex-shrink-0" :name="user?.user?.display_name ?? ''" />
     <p class="mt-1">
       {{ user?.rank }}<span v-if="user?.rank == 1">st </span>
       <span v-if="user?.rank == 2">nd </span>

--- a/components/leaderboard/UserCard.vue
+++ b/components/leaderboard/UserCard.vue
@@ -13,11 +13,7 @@
       <SvgLevel7Icon v-else-if="item.rank == 6" />
       <SvgLevel8Icon v-else-if="item.rank == 7" />
       <SvgLevel9Icon v-else />
-      <img
-        :src="item?.user?.avatar_url ?? '/images/user1.jpg'"
-        class="h-20 w-20 rounded-full object-cover"
-        :alt="t('AltAttributes.UserAvatar')"
-      />
+      <Avatar :name="item?.user?.display_name ?? ''" class="h-20 w-20 flex-shrink-0" />
       <p
         :class="[
           {

--- a/components/user/Profile.vue
+++ b/components/user/Profile.vue
@@ -1,9 +1,8 @@
 <template>
   <section class="card bg-secondary style-card">
-    <img
-      :src="image"
-      :alt="t('AltAttributes.UserAvatar')"
-      class="mx-auto h-32 w-32 rounded-full bg-tertiary shadow-xl shadow-primary mb-box"
+    <Avatar
+      :name="nickname || username"
+      class="mx-auto h-32 w-32 shadow-xl shadow-primary mb-box"
     />
     <h2 class="clamp line-1 text-heading-2 text-center">{{ username }}</h2>
     <p class="clamp line-1 text-body-1 text-center">{{ nickname }}</p>
@@ -44,10 +43,6 @@ export default {
   components: { EnvelopeIcon, CalendarIcon },
   setup(props) {
     const { t } = useI18n();
-
-    const image = computed(() => {
-      return props.data?.avatar_url ?? "/images/about-2.webp";
-    });
 
     const username = computed(() => {
       return props.data?.name ?? "";

--- a/locales/de.json
+++ b/locales/de.json
@@ -978,8 +978,7 @@
     "Newsletter": "Ich möchte mich für den Bootstrap-Newsletter anmelden.",
     "RightToWithdrawal": "Dir steht ein 14-tägiges Widerrufsrecht zu. Widerrufsbelehrung + Widerrufsformular findest du",
     "RightToWithdrawalLink": "hier",
-    "DontUseRightToWithdrawal": "Ich verlange, dass die Dienstleister vor Ende der Widerrufsfrist mit der in Auftrag gegebenen Dienstleistung beginnen.",
-    "GravatarImage": "Ändere dein Gravatar-Bild unter"
+    "DontUseRightToWithdrawal": "Ich verlange, dass die Dienstleister vor Ende der Widerrufsfrist mit der in Auftrag gegebenen Dienstleistung beginnen."
   },
   "Success": {
     "SolvedMatching": "Matching gelöst ✅",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -979,8 +979,7 @@
     "Newsletter": "I want to register for Bootstrap newsletter.",
     "RightToWithdrawal": "You have a 14-day right of withdrawal. You will find the cancellation policy + cancellation form",
     "RightToWithdrawalLink": "here",
-    "DontUseRightToWithdrawal": "I request that you start the commissioned service before the end of the cancellation period.",
-    "GravatarImage": "Change your gravatar image at"
+    "DontUseRightToWithdrawal": "I request that you start the commissioned service before the end of the cancellation period."
   },
   "Success": {
     "SolvedMatching": "Matching Solved ✅",

--- a/pages/dev/form.vue
+++ b/pages/dev/form.vue
@@ -16,14 +16,7 @@
           v-model="form.image.url"
           @file="form.image.value = $event"
           @valid="form.image.valid = $event"
-        >
-          <template #hint="{ t }">
-            {{ t("Links.GravatarImage") }}
-            <a href="https://de.gravatar.com/" target="_blank" class="cursor-pointer">
-              gravatar.com
-            </a>
-          </template>
-        </InputMedia>
+        />
 
         <InputMedia
           label="Inputs.CourseVideo"

--- a/types/calenderTypes.ts
+++ b/types/calenderTypes.ts
@@ -21,7 +21,6 @@ export class EventBase {
 }
 
 export class Instructor {
-  avatar_url: string = "";
   display_name: string = "";
   email: string = "";
   id: string = "";
@@ -42,12 +41,10 @@ export class CoachingEvent extends EventBase {
     name: string;
     display_name: string;
     email: string;
-    avatar_url: string;
   } = {
     id: "",
     name: "",
     display_name: "",
     email: "",
-    avatar_url: "",
   };
 }

--- a/types/userTypes.ts
+++ b/types/userTypes.ts
@@ -1,6 +1,5 @@
 export class User {
   admin: boolean = false;
-  avatar_url: string = "";
   business: boolean = false;
   can_buy_coins: boolean = false;
   can_receive_coins: boolean = false;


### PR DESCRIPTION
## What

Every avatar on the platform was an `<img>` bound to the backend's `avatar_url`,
which was a Gravatar URL derived from `sha256(email)`. Rendering one made the
visitor's browser send a hash of that account's email address, plus the
visitor's IP, to a third party on every page view.

No avatar makes a network request any more.

## How avatars render now

New `components/Avatar.vue`: an inline SVG that draws the initials of the
display name (first + last word, uppercased) on a neutral `bg-tertiary` circle.
It is auto-imported, takes `name` and an optional already-translated `alt`, and
because it uses a `viewBox` the initials scale with whatever size classes the
caller passes — the existing `h-6 w-6` … `h-40 w-40` sites keep their sizing.
Empty display name renders a plain circle. No image file, no request, no
upload feature.

Replaced at every call site:

- `components/NavbarMenu.vue`
- `components/user/Profile.vue`
- `components/form/Profile.vue` (also drops the read-only `InputMedia`
  preview whose only purpose was to carry the Gravatar hint)
- `components/leaderboard/UserCard.vue`, `components/leaderboard/TopUserCard.vue`
- `components/calendar/Event.vue`, `components/calendar/EventSummary.vue` (instructor)
- `components/form/WebinarRating.vue` (instructor)

Course and challenge authors were never rendered with an avatar — they are
name/URL text links in `components/course/Header.vue` — so nothing changed there.

## Also removed

- The "change your gravatar image at gravatar.com" link in the profile edit
  form and in the `/dev/form` playground, plus the `Links.GravatarImage` key in
  both locale files.
- `avatar_url` from `types/userTypes.ts` and from `Instructor` /
  `CoachingEvent.student` in `types/calenderTypes.ts`, so nothing reads the
  field again. The backend now returns `null` for it
  (Bootstrap-Academy/backend#720).

`AltAttributes.UserAvatar` and `AltAttributes.EventInstructorAvatar` stay — the
new component uses them as its accessible label.

## Verification

- `npm run format:check`, `npm run lint` — clean
- `npm run build` — succeeds
- The build output contains **zero** `gravatar.com` URLs. The string
  "Gravatar" survives in exactly one place: the sentence in the privacy notice
  stating that it is no longer used.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)