### PR TITLE
feat(courses): load YouTube lecture videos only after a click

### DIFF
--- a/components/course/Video.vue
+++ b/components/course/Video.vue
@@ -1,21 +1,41 @@
 <template>
   <article v-if="videoSRC && activeLecture">
-    <iframe
-      v-if="activeLecture.type == 'youtube'"
-      :src="videoSRC"
-      title="YouTube player"
-      frameborder="0"
-      allow="
-        accelerometer;
-        autoplay;
-        clipboard-write;
-        encrypted-media;
-        gyroscope;
-        picture-in-picture;
-      "
-      allowfullscreen
-      :key="`youtube-${activeLecture.id}`"
-    ></iframe>
+    <template v-if="activeLecture.type == 'youtube'">
+      <iframe
+        v-if="youtubeLoaded"
+        :src="youtubeEmbedSRC"
+        title="YouTube player"
+        frameborder="0"
+        allow="
+          accelerometer;
+          autoplay;
+          clipboard-write;
+          encrypted-media;
+          gyroscope;
+          picture-in-picture;
+        "
+        allowfullscreen
+        :key="`youtube-${activeLecture.id}`"
+      ></iframe>
+
+      <div v-else :key="`youtube-placeholder-${activeLecture.id}`">
+        <div
+          class="video-placeholder card flex flex-col items-center justify-center bg-secondary text-center gap-card"
+        >
+          <PlayCircleIcon class="h-16 w-16 text-accent" />
+          <p class="text-heading-4 max-w-full break-words">{{ activeLecture.title ?? "" }}</p>
+          <Btn :icon="PlayIcon" @click="loadYoutubeVideo">{{ t("Buttons.LoadVideo") }}</Btn>
+        </div>
+
+        <p class="text-body-2 text-body mt-box">
+          {{ t("Links.VideoPrivacyHint") }}
+          <NuxtLink to="/docs/privacy" target="_blank" class="text-accent hover:underline">{{
+            t("Links.PrivacyNoticeLinkText")
+          }}</NuxtLink
+          >{{ t("Links.PrivacyNoticeHintEnd") }}
+        </p>
+      </div>
+    </template>
 
     <video
       ref="video"
@@ -46,6 +66,8 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import type { PropType } from "vue";
+import { useI18n } from "vue-i18n";
+import { PlayCircleIcon, PlayIcon } from "@heroicons/vue/24/solid";
 
 export default defineComponent({
   props: {
@@ -55,14 +77,31 @@ export default defineComponent({
   },
   setup(props) {
     const videoSRC = useVideoSRC();
+    const { t } = useI18n();
 
     let videoInterval: any;
     const video = ref<HTMLVideoElement | null>(null);
     const refSource = ref<HTMLSourceElement | any>(null);
 
+    // YouTube embeds are only mounted after an explicit click, so that no request
+    // reaches Google before the user asks for it. The choice is deliberately not
+    // persisted anywhere: it is asked again for every lecture and every visit.
+    const youtubeLoaded = ref(false);
+
+    const youtubeEmbedSRC = computed(() => {
+      if (!!!videoSRC.value) return "";
+      return `${videoSRC.value}${videoSRC.value.includes("?") ? "&" : "?"}autoplay=1`;
+    });
+
+    function loadYoutubeVideo() {
+      youtubeLoaded.value = true;
+    }
+
     watch(
       () => props.activeLecture,
       async (newValue, oldValue) => {
+        youtubeLoaded.value = false;
+
         if (!!!newValue) return;
 
         const courseID = props.course?.id ?? "";
@@ -118,7 +157,18 @@ export default defineComponent({
       }
     }
 
-    return { videoSRC, refSource, onTimeUpdate, onVideoLoad };
+    return {
+      t,
+      videoSRC,
+      refSource,
+      onTimeUpdate,
+      onVideoLoad,
+      youtubeLoaded,
+      youtubeEmbedSRC,
+      loadYoutubeVideo,
+      PlayCircleIcon,
+      PlayIcon,
+    };
   },
 });
 </script>
@@ -142,6 +192,22 @@ iframe {
   video,
   iframe {
     @apply h-[90vh] w-full max-w-full;
+  }
+}
+
+/* The placeholder mirrors the player box, but grows instead of clipping its content. */
+.video-placeholder {
+  @apply h-fit w-full min-w-[50vw] max-w-full style-card md:min-h-[60vh];
+}
+@media only screen and (max-width: 768px) and (max-aspect-ratio: 1/1) {
+  .video-placeholder {
+    @apply w-full max-w-full;
+    min-height: calc(100vw * 0.5);
+  }
+}
+@media only screen and (max-width: 768px) and (min-aspect-ratio: 1/1) {
+  .video-placeholder {
+    @apply min-h-[90vh] w-full max-w-full;
   }
 }
 </style>

--- a/composables/courses.ts
+++ b/composables/courses.ts
@@ -140,7 +140,7 @@ export async function getLectureVideoSRC(courseID: string, { id, video_id, type 
         throw { data: { detail: "Invalid lecture video id" } };
       }
 
-      videoSRC.value = `https://www.youtube.com/embed/${video_id}?rel=0`;
+      videoSRC.value = `https://www.youtube-nocookie.com/embed/${video_id}?rel=0`;
       return [true, null];
     }
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -908,7 +908,8 @@
     "CalendarNextMonth": "Nächster Monat",
     "CalendarPrevMonth": "Vorheriger Monat",
     "MoreEventInfo": "Mehr Infos",
-    "LearnMore": "Mehr erfahren"
+    "LearnMore": "Mehr erfahren",
+    "LoadVideo": "Video laden"
   },
   "Links": {
     "LeaderBoard": "Bestenliste",
@@ -978,7 +979,8 @@
     "Newsletter": "Ich möchte mich für den Bootstrap-Newsletter anmelden.",
     "RightToWithdrawal": "Dir steht ein 14-tägiges Widerrufsrecht zu. Widerrufsbelehrung + Widerrufsformular findest du",
     "RightToWithdrawalLink": "hier",
-    "DontUseRightToWithdrawal": "Ich verlange, dass die Dienstleister vor Ende der Widerrufsfrist mit der in Auftrag gegebenen Dienstleistung beginnen."
+    "DontUseRightToWithdrawal": "Ich verlange, dass die Dienstleister vor Ende der Widerrufsfrist mit der in Auftrag gegebenen Dienstleistung beginnen.",
+    "VideoPrivacyHint": "Beim Abspielen werden Daten an YouTube (Google) übertragen. Details in unseren"
   },
   "Success": {
     "SolvedMatching": "Matching gelöst ✅",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -913,7 +913,8 @@
     "CalendarNextMonth": "Next month",
     "CalendarPrevMonth": "Previous month",
     "MoreEventInfo": "More info",
-    "LearnMore": "Learn More"
+    "LearnMore": "Learn More",
+    "LoadVideo": "Load video"
   },
   "Links": {
     "LeaderBoard": "LeaderBoard",
@@ -979,7 +980,8 @@
     "Newsletter": "I want to register for Bootstrap newsletter.",
     "RightToWithdrawal": "You have a 14-day right of withdrawal. You will find the cancellation policy + cancellation form",
     "RightToWithdrawalLink": "here",
-    "DontUseRightToWithdrawal": "I request that you start the commissioned service before the end of the cancellation period."
+    "DontUseRightToWithdrawal": "I request that you start the commissioned service before the end of the cancellation period.",
+    "VideoPrivacyHint": "Playing the video sends data to YouTube (Google). Details are in our"
   },
   "Success": {
     "SolvedMatching": "Matching Solved ✅",


### PR DESCRIPTION
Course lecture videos were embedded as a YouTube iframe that loaded as soon as the watch page rendered. This makes the embed click-to-load.

## What changes

- `components/course/Video.vue` renders a first-party placeholder for `youtube` lectures instead of the iframe: a neutral panel with a play icon, the lecture title and a **Video laden / Load video** button, plus a one-line notice below it linking to `/docs/privacy`. No YouTube thumbnail is fetched, so nothing is requested from Google (or `i.ytimg.com`) on page view.
- The iframe is mounted on click, with `autoplay=1` appended so playback starts right away.
- `composables/courses.ts` builds the embed URL from `www.youtube-nocookie.com` instead of `www.youtube.com`; `?rel=0` is kept.
- The choice is deliberately not persisted — no cookie, no local storage. The button appears again for every lecture and every visit.

`mp4` lectures are untouched, and so are the `currentVideo` / `currentVideoTime` progress cookies (they are only wired to the `<video>` element).

## Strings

Two new keys per locale, reusing the existing privacy-notice link text:

| Key | de | en |
| --- | --- | --- |
| `Buttons.LoadVideo` | Video laden | Load video |
| `Links.VideoPrivacyHint` | Beim Abspielen werden Daten an YouTube (Google) übertragen. Details in unseren | Playing the video sends data to YouTube (Google). Details are in our |

Rendered German line: „Beim Abspielen werden Daten an YouTube (Google) übertragen. Details in unseren [Datenschutzhinweisen](/docs/privacy)."

## Checks

- `npm run lint` — clean
- `npx prettier --check "**/*.{js,ts,vue,json,md,css,scss,html}"` — clean
- `npm run build` — succeeds; the built bundle contains `https://www.youtube-nocookie.com/embed` and no plain `youtube.com/embed` or `ytimg` string

🤖 Generated with [Claude Code](https://claude.com/claude-code)