### PR TITLE
feat: add cancellation and withdrawal pages with a permanent button

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,6 +7,15 @@
     </LazyClientOnly>
     <NuxtPage />
 
+    <!--
+      § 312k Abs. 2 BGB (cancellation) and § 356a BGB (withdrawal) require a
+      permanently available button. Rendered here, inside `<NuxtLayout>` and
+      right after the page, it lands in the slot of every layout - `default`,
+      `inner`, `empty` and `errorLayout` alike - and therefore appears on
+      every route.
+    -->
+    <ContractTermination />
+
     <Modal v-if="dialog && dialog.show" @backdrop="handleDialogOnBackdrop()">
       <Dialog :dialog="dialog" />
     </Modal>

--- a/components/ContractTermination.vue
+++ b/components/ContractTermination.vue
@@ -1,0 +1,38 @@
+<!--
+  § 312k Abs. 2 BGB requires the cancellation button to be permanently
+  available, and § 356a BGB the same for the withdrawal button. The bar is
+  rendered from `app.vue` into the slot of whichever layout is active, so it
+  reaches every route no matter which layout the page asks for.
+
+  It is hidden while printing, because the printed sheet has to show the
+  declaration record only.
+-->
+<template>
+  <nav
+    class="container-fluid flex flex-wrap items-center justify-center gap-4 border-t border-tertiary bg-secondary py-4 print:hidden"
+    :aria-label="t('Headings.ContractTermination')"
+  >
+    <NuxtLink to="/vertrag-kuendigen">
+      <Btn class="!normal-case">{{ t("Buttons.CancelContractsHere") }}</Btn>
+    </NuxtLink>
+
+    <NuxtLink to="/vertrag-widerrufen">
+      <Btn class="!normal-case">{{ t("Buttons.WithdrawFromContract") }}</Btn>
+    </NuxtLink>
+  </nav>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { useI18n } from "vue-i18n";
+
+export default defineComponent({
+  setup() {
+    const { t } = useI18n();
+
+    return { t };
+  },
+});
+</script>
+
+<style scoped></style>

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -1,5 +1,7 @@
 <template>
-  <footer class="container-fluid relative z-0 flex flex-col items-center gap-7 bg-tertiary pt-8">
+  <footer
+    class="container-fluid relative z-0 flex flex-col items-center gap-7 bg-tertiary pt-8 print:hidden"
+  >
     <img
       src="/images/logo-text.png"
       :alt="t('AltAttributes.BootstrapAcademyLogo')"
@@ -70,6 +72,17 @@ export default defineComponent({
     ];
 
     let usefulLinks = [
+      // The two statutory declaration pages are additionally reachable from
+      // here; the permanent bar in `components/ContractTermination.vue` is
+      // what § 312k Abs. 2 BGB and § 356a BGB actually require.
+      {
+        label: "Links.CancelContractsHere",
+        pathname: "/vertrag-kuendigen",
+      },
+      {
+        label: "Links.WithdrawFromContract",
+        pathname: "/vertrag-widerrufen",
+      },
       {
         label: "Links.Privacy",
         pathname: "/docs/privacy",

--- a/components/Language.vue
+++ b/components/Language.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="h-7.5 relative w-screen overflow-clip" :class="color">
+  <section class="h-7.5 relative w-screen overflow-clip print:hidden" :class="color">
     <article class="container-fluid flex h-fit justify-end gap-3 py-1.5">
       <img
         @click="locale = 'en-US'"

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="container-fluid flex items-center justify-between py-4">
+  <section class="container-fluid flex items-center justify-between py-4 print:hidden">
     <!-- START -->
     <NuxtLink :to="authorized ? '/dashboard' : '/'" class="hidden items-center gap-card-sm lg:flex">
       <img

--- a/components/NavbarBack.vue
+++ b/components/NavbarBack.vue
@@ -1,5 +1,7 @@
 <template>
-  <section class="container-fluid flex items-center justify-between gap-4 bg-secondary">
+  <section
+    class="container-fluid flex items-center justify-between gap-4 bg-secondary print:hidden"
+  >
     <Btn tertiary :icon="ArrowLeftIcon" @click="onclickNavigate">
       <img
         src="/images/logo.png"

--- a/composables/contracts.ts
+++ b/composables/contracts.ts
@@ -1,0 +1,99 @@
+/**
+ * Declarations a consumer can hand in without an account:
+ *
+ * - the cancellation of a contract (§ 312k BGB) and
+ * - the withdrawal from a contract (§ 356a BGB).
+ *
+ * Both endpoints are public. The contract is identified by the e-mail address
+ * it is held under, so no session is required.
+ */
+
+export async function declareCancellation(body: any) {
+  try {
+    const response = await POST(`/contracts/cancellations`, body);
+
+    return [response, null];
+  } catch (error: any) {
+    return [null, error?.data ?? null];
+  }
+}
+
+export async function declareWithdrawal(body: any) {
+  try {
+    const response = await POST(`/contracts/withdrawals`, body);
+
+    return [response, null];
+  } catch (error: any) {
+    return [null, error?.data ?? null];
+  }
+}
+
+/**
+ * The receipt of a declaration is documented in Europe/Berlin time so that the
+ * record on screen carries the same moment as the confirmation e-mail, no
+ * matter which time zone the browser is set to.
+ */
+export const DECLARATION_TIME_ZONE = "Europe/Berlin";
+
+/** `2026-09-03T12:12:05Z` -> `03.09.2026, 14:12:05` (de) */
+export function formatDeclarationDateTime(value: string, locale: string) {
+  const date = new Date(value);
+  if (!!!value || Number.isNaN(date.getTime())) return "";
+
+  return new Intl.DateTimeFormat(locale, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZone: DECLARATION_TIME_ZONE,
+  }).format(date);
+}
+
+/** `2026-10-01T00:00:00Z` -> `01.10.2026` (de) */
+export function formatDeclarationDate(value: string, locale: string) {
+  const date = new Date(value);
+  if (!!!value || Number.isNaN(date.getTime())) return "";
+
+  return new Intl.DateTimeFormat(locale, {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    timeZone: DECLARATION_TIME_ZONE,
+  }).format(date);
+}
+
+/**
+ * The date picked in a `type="date"` input (`2026-12-31`) as the ISO-8601 UTC
+ * timestamp the API expects, or `null` for "at the earliest possible date".
+ */
+export function toRequestedEnd(date: string) {
+  return !!date ? `${date}T00:00:00Z` : null;
+}
+
+/** The contract options offered on the two declaration pages. */
+export const CONTRACT_LABELS: Record<string, string> = {
+  COINS: "Inputs.ContractCoins",
+  PREMIUM: "Inputs.ContractPremium",
+  OTHER: "Inputs.ContractOther",
+};
+
+/** The kinds of cancellation offered on the cancellation page. */
+export const CANCELLATION_TYPE_LABELS: Record<string, string> = {
+  ORDINARY: "Inputs.OrdinaryCancellation",
+  EXTRAORDINARY: "Inputs.ExtraordinaryCancellation",
+};
+
+/**
+ * The locale key for the snackbar shown when a declaration could not be
+ * handed in. The consumer must never be left without a way to declare, so
+ * every unknown failure falls back to the message naming our e-mail address.
+ */
+export function declarationErrorKey(error: any) {
+  const detail = error?.detail;
+
+  return typeof detail === "string" && detail.startsWith("Error.")
+    ? detail
+    : "Error.DeclarationNotSubmitted";
+}

--- a/composables/fetch.js
+++ b/composables/fetch.js
@@ -180,6 +180,8 @@ const onResponseError = async (context) => {
     return (response._data.detail = "Error.NotEnoughCoins");
   } else if (details.includes("cannot start in the past")) {
     return (response._data.detail = "Error.CannotStartInPast");
+  } else if (details.includes("too many requests")) {
+    return (response._data.detail = "Error.TooManyRequests");
   } else if (details.includes("email not verified")) {
     // return openSnackbar("error", "Error.AccountNotVerified");
     return (response._data.detail = "Error.AccountNotVerified");

--- a/error.vue
+++ b/error.vue
@@ -11,6 +11,13 @@
         <InputBtn class="w-full" @click="navigateTo('/')"> Go Home </InputBtn>
       </section>
     </main>
+
+    <!--
+      `app.vue` is not rendered for the error page, so the permanently
+      available buttons required by § 312k Abs. 2 BGB and § 356a BGB are added
+      here as well.
+    -->
+    <ContractTermination />
   </NuxtLayout>
 </template>
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -361,7 +361,16 @@
     "NetAmount": "Nettobetrag",
     "VatAmount": "MwSt. ({vat} %)",
     "AutomaticRenewal": "Automatische Verlängerung",
-    "ContractTerm": "Laufzeit"
+    "ContractTerm": "Laufzeit",
+    "CancelContract": "Vertrag kündigen",
+    "WithdrawContract": "Vertrag widerrufen",
+    "CancellationReceived": "Ihre Kündigung ist bei uns eingegangen.",
+    "WithdrawalReceived": "Ihr Widerruf ist bei uns eingegangen.",
+    "DeclarationReceivedAt": "Eingang der Erklärung",
+    "DeclarationReference": "Vorgangsnummer",
+    "CancellationReason": "Grund der Kündigung",
+    "OrderDetails": "Angaben zur Bestellung",
+    "ContractTermination": "Vertragsbeendigung"
   },
   "Body": {
     "DashboardIntro": "Steig direkt wieder in deine Kurse oder Challenges ein.",
@@ -493,7 +502,18 @@
     "AutomaticRenewalOn": "Ein — nach Ablauf wird automatisch verlängert und erneut in Morphcoins abgebucht. Du kannst die automatische Verlängerung auf dieser Seite jederzeit abschalten.",
     "AutomaticRenewalOff": "Aus — die Mitgliedschaft endet mit Ablauf der Laufzeit. Eine automatische Verlängerung kannst du auf dieser Seite einschalten.",
     "PremiumTermMonthly": "1 Monat ab Kauf",
-    "PremiumTermYearly": "12 Monate ab Kauf"
+    "PremiumTermYearly": "12 Monate ab Kauf",
+    "CancelContractIntro": "Mit diesem Formular können Sie Ihren Vertrag mit der bootstrap academy GmbH kündigen. Sie benötigen dafür weder ein Konto noch eine Anmeldung. Den Eingang Ihrer Kündigung bestätigen wir Ihnen sofort per E-Mail; den Inhalt Ihrer Erklärung können Sie anschließend speichern oder ausdrucken.",
+    "WithdrawContractIntro": "Mit diesem Formular können Sie Ihren Vertrag mit der bootstrap academy GmbH widerrufen. Sie benötigen dafür weder ein Konto noch eine Anmeldung. Den Eingang Ihres Widerrufs bestätigen wir Ihnen sofort per E-Mail; den Inhalt Ihrer Erklärung können Sie anschließend speichern oder ausdrucken.",
+    "ContractEmailHint": "Bitte geben Sie die E-Mail-Adresse an, mit der Ihr Konto bzw. Ihr Vertrag geführt wird.",
+    "OrderReferenceHint": "Die Bestellnummer finden Sie in der Bestellbestätigungs-E-Mail zu Ihrer Bestellung.",
+    "DeclarationReceivedAtValue": "{datetime} Uhr (Zeitzone Europe/Berlin)",
+    "EndAtNextPossibleDate": "zum nächstmöglichen Zeitpunkt",
+    "ContractEndsOn": "Ihr Vertrag endet am {date}.",
+    "NoContractFoundForEmail": "Den Zeitpunkt, zu dem der Vertrag endet, können wir zu Ihren Angaben nicht automatisch ermitteln. Wir prüfen Ihre Kündigung und bestätigen Ihnen den Beendigungszeitpunkt gesondert per E-Mail.",
+    "ConfirmationEmailSent": "Eine Bestätigung mit diesem Inhalt haben wir Ihnen soeben per E-Mail an {email} geschickt.",
+    "ConfirmationEmailNotSent": "Die Bestätigungs-E-Mail konnte nicht zugestellt werden. Bitte speichern oder drucken Sie diese Seite.",
+    "CancelPremiumHint": "Dort können Sie Ihre Premium-Mitgliedschaft mit dem gesetzlichen Kündigungsformular kündigen; den Eingang bestätigen wir Ihnen sofort per E-Mail."
   },
   "AltAttributes": {
     "BootstrapAcademyLogo": "Bootstrap Academy Logo",
@@ -704,7 +724,23 @@
     "MFACode": "6-stelliger MFA-Code",
     "RecoveryCode": "Wiederherstellungscode",
     "RegistrationCode": "Registrierungscode",
-    "AnswerOption": "Antwort-Möglichkeit"
+    "AnswerOption": "Antwort-Möglichkeit",
+    "CancellationType": "Art der Kündigung",
+    "OrdinaryCancellation": "Ordentliche Kündigung",
+    "ExtraordinaryCancellation": "Außerordentliche Kündigung",
+    "ExtraordinaryCancellationReason": "Grund der außerordentlichen Kündigung (optional)",
+    "DeclarationName": "Name",
+    "DeclarationEmail": "E-Mail-Adresse",
+    "Contract": "Vertrag",
+    "ContractOrOrder": "Vertrag / Bestellung",
+    "ContractCoins": "MorphCoin-Kauf",
+    "ContractPremium": "Premium-Mitgliedschaft",
+    "ContractOther": "Sonstiger Vertrag",
+    "EndOfContract": "Beendigungszeitpunkt",
+    "EndAtNextPossibleDate": "Zum nächstmöglichen Zeitpunkt",
+    "EndAtDate": "Zum folgenden Datum",
+    "EndDate": "Beendigungsdatum",
+    "OrderDetails": "Bestellnummer oder sonstige Angaben zur Bestellung (optional)"
   },
   "Buttons": {
     "Matching": "Matching",
@@ -843,7 +879,13 @@
     "LearnMore": "Mehr erfahren",
     "LoadVideo": "Video laden",
     "OrderWithObligationToPay": "Zahlungspflichtig bestellen",
-    "ContinueToOrderSummary": "Weiter zur Bestellübersicht"
+    "ContinueToOrderSummary": "Weiter zur Bestellübersicht",
+    "CancelContractsHere": "Verträge hier kündigen",
+    "WithdrawFromContract": "Vertrag widerrufen",
+    "CancelNow": "jetzt kündigen",
+    "WithdrawNow": "jetzt widerrufen",
+    "SaveAsPdfOrPrint": "Als PDF speichern / Drucken",
+    "CancelPremium": "Premium kündigen"
   },
   "Links": {
     "LeaderBoard": "Bestenliste",
@@ -914,7 +956,9 @@
     "OrderLegalHint": "Es gelten unsere",
     "OrderLegalHintMiddle": "und die",
     "OrderLegalHintEnd": ".",
-    "RightOfWithdrawalLinkText": "Widerrufsbelehrung"
+    "RightOfWithdrawalLinkText": "Widerrufsbelehrung",
+    "CancelContractsHere": "Verträge hier kündigen",
+    "WithdrawFromContract": "Vertrag widerrufen"
   },
   "Success": {
     "SolvedMatching": "Matching gelöst ✅",
@@ -972,7 +1016,9 @@
     "BookedExam": "Die Buchung deiner Prüfung war erfolgreich.",
     "BookedCoaching": "Die Buchung deiner Coaching-Sitzung war erfolgreich.",
     "BookedWebinar": "Die Buchung des Webinar war erfolgreich.",
-    "OAuthSuccess": "Login mit OAuth war erfolgreich. Füge jetzt bitte deine Kontoinformationen hinzu, um deinen Anmeldevorgang abzuschließen."
+    "OAuthSuccess": "Login mit OAuth war erfolgreich. Füge jetzt bitte deine Kontoinformationen hinzu, um deinen Anmeldevorgang abzuschließen.",
+    "CancellationDeclared": "Ihre Kündigung ist bei uns eingegangen.",
+    "WithdrawalDeclared": "Ihr Widerruf ist bei uns eingegangen."
   },
   "Error": {
     "WrongMatchingAttempt": "Falsches Matching ❌. Versuchen Sie es erneut",
@@ -1084,7 +1130,9 @@
     "PasswordResetFailed": "Kennwort kann nicht zurückgesetzt werden. Bitte probier es später erneut.",
     "InvalidCode": "Dieser Code ist ungültig.",
     "ProviderNotFound": "Dieser Anbieter kann nicht gefunden werden.",
-    "InvalidCoinAmount": "Ungültige Anzahl an Morphcoins. Bitte starte den Kauf erneut."
+    "InvalidCoinAmount": "Ungültige Anzahl an Morphcoins. Bitte starte den Kauf erneut.",
+    "TooManyRequests": "Zu viele Anfragen. Bitte versuchen Sie es später erneut oder schreiben Sie uns an hallo{'@'}bootstrap.academy.",
+    "DeclarationNotSubmitted": "Ihre Erklärung konnte nicht übermittelt werden. Bitte versuchen Sie es erneut oder senden Sie Ihre Erklärung an hallo{'@'}bootstrap.academy."
   },
   "Months": {
     "January": "Januar",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -361,7 +361,16 @@
     "NetAmount": "Net amount",
     "VatAmount": "VAT ({vat}%)",
     "AutomaticRenewal": "Automatic renewal",
-    "ContractTerm": "Term"
+    "ContractTerm": "Term",
+    "CancelContract": "Cancel contract",
+    "WithdrawContract": "Withdraw from contract",
+    "CancellationReceived": "We have received your cancellation.",
+    "WithdrawalReceived": "We have received your withdrawal.",
+    "DeclarationReceivedAt": "Declaration received",
+    "DeclarationReference": "Reference number",
+    "CancellationReason": "Reason for the cancellation",
+    "OrderDetails": "Order details",
+    "ContractTermination": "Ending a contract"
   },
   "Body": {
     "DashboardIntro": "Jump back into your courses or challenges to keep the momentum going.",
@@ -494,7 +503,18 @@
     "AutomaticRenewalOn": "On — the membership renews automatically when it expires and is charged in Morphcoins again. You can switch automatic renewal off on this page at any time.",
     "AutomaticRenewalOff": "Off — the membership ends when the term expires. You can switch automatic renewal on from this page.",
     "PremiumTermMonthly": "1 month from the purchase",
-    "PremiumTermYearly": "12 months from the purchase"
+    "PremiumTermYearly": "12 months from the purchase",
+    "CancelContractIntro": "Use this form to cancel your contract with bootstrap academy GmbH. You need neither an account nor a login. We confirm the receipt of your cancellation by e-mail immediately; you can save or print the content of your declaration afterwards.",
+    "WithdrawContractIntro": "Use this form to withdraw from your contract with bootstrap academy GmbH. You need neither an account nor a login. We confirm the receipt of your withdrawal by e-mail immediately; you can save or print the content of your declaration afterwards.",
+    "ContractEmailHint": "Please enter the e-mail address your account or contract is held under.",
+    "OrderReferenceHint": "You will find the order number in the purchase confirmation e-mail for your order.",
+    "DeclarationReceivedAtValue": "{datetime} (time zone Europe/Berlin)",
+    "EndAtNextPossibleDate": "at the earliest possible date",
+    "ContractEndsOn": "Your contract ends on {date}.",
+    "NoContractFoundForEmail": "We cannot determine the end of the contract automatically from your details. We will review your cancellation and confirm the end date separately by e-mail.",
+    "ConfirmationEmailSent": "We have just sent you a confirmation with this content by e-mail to {email}.",
+    "ConfirmationEmailNotSent": "The confirmation e-mail could not be delivered. Please save or print this page.",
+    "CancelPremiumHint": "There you can cancel your premium membership with the statutory cancellation form; we confirm the receipt by e-mail immediately."
   },
   "AltAttributes": {
     "BootstrapAcademyLogo": "Bootstrap Academy logo",
@@ -705,7 +725,23 @@
     "MFACode": "MFA 6 digit Code",
     "RecoveryCode": "Recovery Code",
     "RegistrationCode": "Registration Code",
-    "AnswerOption": "Answer Option"
+    "AnswerOption": "Answer Option",
+    "CancellationType": "Type of cancellation",
+    "OrdinaryCancellation": "Ordinary cancellation",
+    "ExtraordinaryCancellation": "Extraordinary cancellation",
+    "ExtraordinaryCancellationReason": "Reason for the extraordinary cancellation (optional)",
+    "DeclarationName": "Name",
+    "DeclarationEmail": "E-mail address",
+    "Contract": "Contract",
+    "ContractOrOrder": "Contract / order",
+    "ContractCoins": "MorphCoin purchase",
+    "ContractPremium": "Premium membership",
+    "ContractOther": "Other contract",
+    "EndOfContract": "End of the contract",
+    "EndAtNextPossibleDate": "At the earliest possible date",
+    "EndAtDate": "On the following date",
+    "EndDate": "End date",
+    "OrderDetails": "Order number or other details of the order (optional)"
   },
   "Buttons": {
     "Matching": "Matching",
@@ -849,7 +885,13 @@
     "LearnMore": "Learn More",
     "LoadVideo": "Load video",
     "OrderWithObligationToPay": "Order with obligation to pay",
-    "ContinueToOrderSummary": "Continue to the order summary"
+    "ContinueToOrderSummary": "Continue to the order summary",
+    "CancelContractsHere": "Cancel contracts here",
+    "WithdrawFromContract": "Withdraw from contract",
+    "CancelNow": "cancel now",
+    "WithdrawNow": "withdraw now",
+    "SaveAsPdfOrPrint": "Save as PDF / Print",
+    "CancelPremium": "Cancel Premium"
   },
   "Links": {
     "LeaderBoard": "LeaderBoard",
@@ -916,7 +958,9 @@
     "OrderLegalHint": "Our",
     "OrderLegalHintMiddle": "and our",
     "OrderLegalHintEnd": " apply.",
-    "RightOfWithdrawalLinkText": "withdrawal policy"
+    "RightOfWithdrawalLinkText": "withdrawal policy",
+    "CancelContractsHere": "Cancel contracts here",
+    "WithdrawFromContract": "Withdraw from contract"
   },
   "Success": {
     "SolvedMatching": "Matching Solved ✅",
@@ -975,7 +1019,9 @@
     "BookedExam": "Your exam has been booked successfully.",
     "BookedCoaching": "Your coaching session has been booked successfully.",
     "BookedWebinar": "Your webinar has been booked successfully.",
-    "OAuthSuccess": "Your OAuth was successful. Now please add your account information to complete your signup process."
+    "OAuthSuccess": "Your OAuth was successful. Now please add your account information to complete your signup process.",
+    "CancellationDeclared": "We have received your cancellation.",
+    "WithdrawalDeclared": "We have received your withdrawal."
   },
   "Error": {
     "WrongMatchingAttempt": "Incorrect Matchings❌. Try Again",
@@ -1086,7 +1132,9 @@
     "PasswordResetFailed": "Unable to reset password. Please try again later.",
     "InvalidCode": "This code is invalid. Please use a valid one",
     "ProviderNotFound": "Unable to find this provider. Please select another one.",
-    "InvalidCoinAmount": "Invalid number of Morphcoins. Please start the purchase again."
+    "InvalidCoinAmount": "Invalid number of Morphcoins. Please start the purchase again.",
+    "TooManyRequests": "Too many requests. Please try again later or write to us at hallo{'@'}bootstrap.academy.",
+    "DeclarationNotSubmitted": "Your declaration could not be submitted. Please try again or send your declaration to hallo{'@'}bootstrap.academy."
   },
   "Months": {
     "January": "January",

--- a/pages/subscription/index.vue
+++ b/pages/subscription/index.vue
@@ -90,8 +90,21 @@
           secondary
           :buttonOptions="changeSubscriptionAutopayButtons"
           v-model="setValueForAutopayButton"
-          class="mb-20 mt-4"
+          class="mt-4"
         />
+      </div>
+
+      <!--
+        Turning the automatic renewal off is not a cancellation. The statutory
+        route under § 312k BGB, with the confirmation by e-mail, lives on its
+        own page and stays reachable even while no period is currently active -
+        which is exactly when the toggle above is unavailable.
+      -->
+      <div class="mb-20 mt-10 flex flex-col items-center">
+        <NuxtLink to="/vertrag-kuendigen">
+          <Btn class="!normal-case">{{ t("Buttons.CancelPremium") }}</Btn>
+        </NuxtLink>
+        <p class="mt-3 max-w-md text-center">{{ t("Body.CancelPremiumHint") }}</p>
       </div>
     </section>
 

--- a/pages/vertrag-kuendigen.vue
+++ b/pages/vertrag-kuendigen.vue
@@ -1,0 +1,406 @@
+<!--
+  Cancellation of a contract under § 312k BGB.
+
+  The page is public: it carries no middleware and no session is required, so
+  the button in `components/ContractTermination.vue` leads here for logged out
+  visitors as well.
+
+  § 312k Abs. 3 BGB requires the consumer to be able to store the content of
+  the declaration together with the date and time of its receipt, which is what
+  the record replacing the form is for.
+
+  Following BGH I ZR 200/25 the page carries nothing but the form, the
+  statutory button and the record - no retention offers, no alternatives to
+  cancelling and no additional confirmation step.
+-->
+
+<template>
+  <main class="mt-main mb-main container">
+    <div class="mx-auto w-full max-w-2xl">
+      <h1 class="text-heading-1 mb-box">{{ t("Headings.CancelContract") }}</h1>
+
+      <!-- ============================================================ FORM -->
+      <template v-if="!!!declaration">
+        <p class="mb-box">{{ t("Body.CancelContractIntro") }}</p>
+
+        <form
+          class="flex flex-col gap-box"
+          :class="{ 'form-submitting': form.submitting }"
+          @submit.prevent="onclickSubmitForm()"
+          ref="refForm"
+        >
+          <fieldset>
+            <legend class="text-body-2 mb-2 block text-body font-body">
+              {{ t("Inputs.CancellationType") }}
+            </legend>
+            <InputRadioGroup
+              name="cancellation-type"
+              :options="cancellationTypes"
+              v-model="form.cancellationType.value"
+            />
+          </fieldset>
+
+          <InputTextarea
+            v-if="isExtraordinary"
+            label="Inputs.ExtraordinaryCancellationReason"
+            v-model="form.reason.value"
+            @valid="form.reason.valid = $event"
+            :rules="form.reason.rules"
+            :max="4096"
+            :rows="4"
+          />
+
+          <Input
+            label="Inputs.DeclarationName"
+            autocomplete="name"
+            v-model="form.name.value"
+            @valid="form.name.valid = $event"
+            :rules="form.name.rules"
+          />
+
+          <Input
+            label="Inputs.DeclarationEmail"
+            type="email"
+            autocomplete="email"
+            hint="Body.ContractEmailHint"
+            v-model="form.email.value"
+            @valid="form.email.valid = $event"
+            :rules="form.email.rules"
+          />
+
+          <InputSelect
+            id="contract"
+            label="Inputs.Contract"
+            :options="contracts"
+            v-model="form.contract.value"
+          />
+
+          <fieldset>
+            <legend class="text-body-2 mb-2 block text-body font-body">
+              {{ t("Inputs.EndOfContract") }}
+            </legend>
+            <InputRadioGroup
+              name="end-of-contract"
+              :options="endOptions"
+              v-model="form.endType.value"
+            />
+          </fieldset>
+
+          <Input
+            v-if="isEndAtDate"
+            type="date"
+            label="Inputs.EndDate"
+            :min="today"
+            v-model="form.endDate.value"
+            @valid="form.endDate.valid = $event"
+            :rules="form.endDate.rules"
+          />
+
+          <InputBtn
+            :loading="form.submitting"
+            class="self-end !normal-case"
+            @click="onclickSubmitForm()"
+            mt
+          >
+            {{ t("Buttons.CancelNow") }}
+          </InputBtn>
+        </form>
+      </template>
+
+      <!-- ========================================================== RECORD -->
+      <section v-else class="declaration-record flex flex-col gap-box">
+        <h2 class="text-heading-2">{{ t("Headings.CancellationReceived") }}</h2>
+
+        <dl class="grid grid-cols-[auto_minmax(0,1fr)] gap-y-1 gap-x-card">
+          <dt class="text-body-1 m-0 text-body">{{ t("Headings.DeclarationReceivedAt") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">
+            {{ t("Body.DeclarationReceivedAtValue", { datetime: receivedAt }) }}
+          </dd>
+
+          <dt class="text-body-1 m-0 text-body">{{ t("Inputs.DeclarationName") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">{{ declaration.name }}</dd>
+
+          <dt class="text-body-1 m-0 text-body">{{ t("Inputs.DeclarationEmail") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">{{ declaration.email }}</dd>
+
+          <dt class="text-body-1 m-0 text-body">{{ t("Inputs.Contract") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">{{ t(contractLabel) }}</dd>
+
+          <dt class="text-body-1 m-0 text-body">{{ t("Inputs.CancellationType") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">{{ t(cancellationTypeLabel) }}</dd>
+
+          <template v-if="!!declaration.details">
+            <dt class="text-body-1 m-0 text-body">{{ t("Headings.CancellationReason") }}</dt>
+            <dd class="text-body-1 m-0 whitespace-pre-line text-heading">
+              {{ declaration.details }}
+            </dd>
+          </template>
+
+          <dt class="text-body-1 m-0 text-body">{{ t("Inputs.EndOfContract") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">
+            {{ requestedEnd || t("Body.EndAtNextPossibleDate") }}
+          </dd>
+
+          <dt class="text-body-1 m-0 text-body">{{ t("Headings.DeclarationReference") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">{{ declaration.id }}</dd>
+        </dl>
+
+        <p v-if="!!effectiveEnd">{{ t("Body.ContractEndsOn", { date: effectiveEnd }) }}</p>
+        <p v-else>{{ t("Body.NoContractFoundForEmail") }}</p>
+
+        <p v-if="confirmationEmailSent">
+          {{ t("Body.ConfirmationEmailSent", { email: declaration.email }) }}
+        </p>
+        <p v-else>{{ t("Body.ConfirmationEmailNotSent") }}</p>
+
+        <Btn class="w-fit print:!hidden" @click="onclickPrint()">
+          {{ t("Buttons.SaveAsPdfOrPrint") }}
+        </Btn>
+      </section>
+    </div>
+  </main>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import type { IForm } from "~/types/form";
+
+export default defineComponent({
+  setup() {
+    const { t, locale } = useI18n();
+
+    useHead({ title: computed(() => t("Headings.CancelContract")) });
+
+    // ============================================================= refs
+    const refForm = ref<HTMLFormElement | null>(null);
+
+    // The declaration returned by the API. As long as it is `null` the form is
+    // shown, afterwards the record replaces it on the same page.
+    const declaration = ref<any>(null);
+    const confirmationEmailSent = ref(false);
+
+    // ============================================================= options
+    const cancellationTypes = [
+      { label: "Inputs.OrdinaryCancellation", value: "ORDINARY" },
+      { label: "Inputs.ExtraordinaryCancellation", value: "EXTRAORDINARY" },
+    ];
+
+    const contracts = [
+      { label: "Inputs.ContractPremium", value: "PREMIUM" },
+      { label: "Inputs.ContractOther", value: "OTHER" },
+    ];
+
+    const endOptions = [
+      { label: "Inputs.EndAtNextPossibleDate", value: "NEXT_POSSIBLE" },
+      { label: "Inputs.EndAtDate", value: "DATE" },
+    ];
+
+    const today = new Date().toISOString().slice(0, 10);
+
+    // ============================================================= reactive
+    const form = reactive<IForm>({
+      cancellationType: {
+        valid: true,
+        value: "ORDINARY",
+      },
+      reason: {
+        valid: true,
+        value: "",
+        rules: [(v: string) => v.length <= 4096 || "Error.InputMaxLength_4096"],
+      },
+      name: {
+        valid: false,
+        value: "",
+        rules: [
+          (v: string) => !!v || "Error.InputEmpty_Inputs.DeclarationName",
+          (v: string) => v.length >= 2 || "Error.InputMinLength_2",
+          (v: string) => v.length <= 256 || "Error.InputMaxLength_256",
+        ],
+      },
+      email: {
+        valid: false,
+        value: "",
+        rules: [
+          (v: string) => !!v || "Error.InputEmpty_Inputs.DeclarationEmail",
+          (v: string) => /.+@.+\..+/.test(v) || "Error.InputEmailForm",
+        ],
+      },
+      contract: {
+        valid: true,
+        value: "PREMIUM",
+      },
+      endType: {
+        valid: true,
+        value: "NEXT_POSSIBLE",
+      },
+      endDate: {
+        valid: true,
+        value: "",
+        rules: [
+          (v: string) => form.endType.value != "DATE" || !!v || "Error.InputEmpty_Inputs.EndDate",
+        ],
+      },
+      submitting: false,
+      validate: () => {
+        let isValid = true;
+
+        for (const key in form) {
+          if (key != "validate" && key != "body" && key != "submitting" && !form[key].valid) {
+            isValid = false;
+          }
+        }
+
+        // The date is only filled in once the second option is picked, so it
+        // cannot be covered by the untouched input alone.
+        if (form.endType.value == "DATE" && !!!form.endDate.value) isValid = false;
+
+        if (refForm.value) refForm.value.reportValidity();
+        return isValid;
+      },
+      body: () => {
+        const extraordinary = form.cancellationType.value == "EXTRAORDINARY";
+        const reason = form.reason.value.trim();
+
+        return {
+          name: form.name.value.trim(),
+          email: form.email.value.trim(),
+          contract: form.contract.value,
+          cancellation_type: form.cancellationType.value,
+          details: extraordinary && !!reason ? reason : null,
+          requested_end: form.endType.value == "DATE" ? toRequestedEnd(form.endDate.value) : null,
+        };
+      },
+    });
+
+    // ============================================================= computed
+    const isExtraordinary = computed(() => form.cancellationType.value == "EXTRAORDINARY");
+    const isEndAtDate = computed(() => form.endType.value == "DATE");
+
+    const receivedAt = computed(() =>
+      formatDeclarationDateTime(declaration.value?.received_at ?? "", locale.value)
+    );
+    const requestedEnd = computed(() =>
+      formatDeclarationDate(declaration.value?.requested_end ?? "", locale.value)
+    );
+    const effectiveEnd = computed(() =>
+      formatDeclarationDate(declaration.value?.effective_end ?? "", locale.value)
+    );
+
+    const contractLabel = computed(
+      () => CONTRACT_LABELS[declaration.value?.contract] ?? "Inputs.ContractOther"
+    );
+    const cancellationTypeLabel = computed(
+      () =>
+        CANCELLATION_TYPE_LABELS[declaration.value?.cancellation_type] ??
+        "Inputs.OrdinaryCancellation"
+    );
+
+    // ============================================================= prefill
+    // A logged in user gets name and e-mail filled in, but both stay editable
+    // and nothing on this page depends on a session.
+    const user = <any>useUser();
+
+    function prefillFromSession() {
+      const profile = user.value;
+      if (!!!profile) return;
+
+      const fullName = [profile.first_name, profile.last_name]
+        .map((part: string) => (part ?? "").trim())
+        .filter((part: string) => !!part)
+        .join(" ");
+
+      const name = fullName || profile.display_name || profile.name || "";
+
+      if (!!name && !!!form.name.value) form.name.value = name;
+      if (!!profile.email && !!!form.email.value) form.email.value = profile.email;
+    }
+
+    watch(user, prefillFromSession, { immediate: true });
+
+    // Keep an abandoned reason from blocking an ordinary cancellation.
+    watch(
+      () => form.cancellationType.value,
+      (value) => {
+        if (value == "EXTRAORDINARY") return;
+        form.reason.value = "";
+        form.reason.valid = true;
+      }
+    );
+
+    watch(
+      () => form.endType.value,
+      (value) => {
+        if (value == "DATE") return;
+        form.endDate.value = "";
+        form.endDate.valid = true;
+      }
+    );
+
+    // ============================================================= functions
+    async function onclickSubmitForm() {
+      if (!form.validate()) return openSnackbar("error", "Error.InvalidForm");
+
+      form.submitting = true;
+
+      const [success, error] = await declareCancellation(form.body());
+
+      form.submitting = false;
+
+      success ? successHandler(success) : errorHandler(error);
+    }
+
+    function successHandler(res: any) {
+      declaration.value = res?.declaration ?? res ?? null;
+      confirmationEmailSent.value = !!res?.confirmation_email_sent;
+
+      openSnackbar("success", "Success.CancellationDeclared");
+    }
+
+    function errorHandler(res: any) {
+      openSnackbar("error", declarationErrorKey(res));
+    }
+
+    function onclickPrint() {
+      window.print();
+    }
+
+    return {
+      t,
+      refForm,
+      form,
+      cancellationTypes,
+      contracts,
+      endOptions,
+      today,
+      isExtraordinary,
+      isEndAtDate,
+      declaration,
+      confirmationEmailSent,
+      receivedAt,
+      requestedEnd,
+      effectiveEnd,
+      contractLabel,
+      cancellationTypeLabel,
+      onclickSubmitForm,
+      onclickPrint,
+    };
+  },
+});
+</script>
+
+<style scoped>
+/*
+  § 312k Abs. 3 BGB: the printed sheet has to reproduce the declaration. The
+  navigation, the language switcher, the footer, the permanent bar and the
+  print button are hidden by a `print:` utility, so only this page remains -
+  in black on white, because the interface itself is a dark theme.
+*/
+@media print {
+  main,
+  main :deep(*) {
+    color: #000 !important;
+    background: transparent !important;
+  }
+}
+</style>

--- a/pages/vertrag-widerrufen.vue
+++ b/pages/vertrag-widerrufen.vue
@@ -1,0 +1,285 @@
+<!--
+  Withdrawal from a contract under § 356a BGB.
+
+  The page is public: it carries no middleware and no session is required, so
+  the button in `components/ContractTermination.vue` leads here for logged out
+  visitors as well.
+
+  § 356a BGB requires the consumer to be able to store the content of the
+  declaration together with the date and time of its receipt, which is what the
+  record replacing the form is for.
+-->
+
+<template>
+  <main class="mt-main mb-main container">
+    <div class="mx-auto w-full max-w-2xl">
+      <h1 class="text-heading-1 mb-box">{{ t("Headings.WithdrawContract") }}</h1>
+
+      <!-- ============================================================ FORM -->
+      <template v-if="!!!declaration">
+        <p class="mb-box">{{ t("Body.WithdrawContractIntro") }}</p>
+
+        <form
+          class="flex flex-col gap-box"
+          :class="{ 'form-submitting': form.submitting }"
+          @submit.prevent="onclickSubmitForm()"
+          ref="refForm"
+        >
+          <Input
+            label="Inputs.DeclarationName"
+            autocomplete="name"
+            v-model="form.name.value"
+            @valid="form.name.valid = $event"
+            :rules="form.name.rules"
+          />
+
+          <Input
+            label="Inputs.DeclarationEmail"
+            type="email"
+            autocomplete="email"
+            hint="Body.ContractEmailHint"
+            v-model="form.email.value"
+            @valid="form.email.valid = $event"
+            :rules="form.email.rules"
+          />
+
+          <InputSelect
+            id="contract"
+            label="Inputs.ContractOrOrder"
+            :options="contracts"
+            v-model="form.contract.value"
+          />
+
+          <InputTextarea
+            label="Inputs.OrderDetails"
+            hint="Body.OrderReferenceHint"
+            v-model="form.details.value"
+            @valid="form.details.valid = $event"
+            :rules="form.details.rules"
+            :max="4096"
+            :rows="4"
+          />
+
+          <InputBtn
+            :loading="form.submitting"
+            class="self-end !normal-case"
+            @click="onclickSubmitForm()"
+            mt
+          >
+            {{ t("Buttons.WithdrawNow") }}
+          </InputBtn>
+        </form>
+      </template>
+
+      <!-- ========================================================== RECORD -->
+      <section v-else class="declaration-record flex flex-col gap-box">
+        <h2 class="text-heading-2">{{ t("Headings.WithdrawalReceived") }}</h2>
+
+        <dl class="grid grid-cols-[auto_minmax(0,1fr)] gap-y-1 gap-x-card">
+          <dt class="text-body-1 m-0 text-body">{{ t("Headings.DeclarationReceivedAt") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">
+            {{ t("Body.DeclarationReceivedAtValue", { datetime: receivedAt }) }}
+          </dd>
+
+          <dt class="text-body-1 m-0 text-body">{{ t("Inputs.DeclarationName") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">{{ declaration.name }}</dd>
+
+          <dt class="text-body-1 m-0 text-body">{{ t("Inputs.DeclarationEmail") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">{{ declaration.email }}</dd>
+
+          <dt class="text-body-1 m-0 text-body">{{ t("Inputs.ContractOrOrder") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">{{ t(contractLabel) }}</dd>
+
+          <template v-if="!!declaration.details">
+            <dt class="text-body-1 m-0 text-body">{{ t("Headings.OrderDetails") }}</dt>
+            <dd class="text-body-1 m-0 whitespace-pre-line text-heading">
+              {{ declaration.details }}
+            </dd>
+          </template>
+
+          <dt class="text-body-1 m-0 text-body">{{ t("Headings.DeclarationReference") }}</dt>
+          <dd class="text-body-1 m-0 text-heading">{{ declaration.id }}</dd>
+        </dl>
+
+        <p v-if="confirmationEmailSent">
+          {{ t("Body.ConfirmationEmailSent", { email: declaration.email }) }}
+        </p>
+        <p v-else>{{ t("Body.ConfirmationEmailNotSent") }}</p>
+
+        <Btn class="w-fit print:!hidden" @click="onclickPrint()">
+          {{ t("Buttons.SaveAsPdfOrPrint") }}
+        </Btn>
+      </section>
+    </div>
+  </main>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import type { IForm } from "~/types/form";
+
+export default defineComponent({
+  setup() {
+    const { t, locale } = useI18n();
+
+    useHead({ title: computed(() => t("Headings.WithdrawContract")) });
+
+    // ============================================================= refs
+    const refForm = ref<HTMLFormElement | null>(null);
+
+    // The declaration returned by the API. As long as it is `null` the form is
+    // shown, afterwards the record replaces it on the same page.
+    const declaration = ref<any>(null);
+    const confirmationEmailSent = ref(false);
+
+    // ============================================================= options
+    const contracts = [
+      { label: "Inputs.ContractCoins", value: "COINS" },
+      { label: "Inputs.ContractPremium", value: "PREMIUM" },
+      { label: "Inputs.ContractOther", value: "OTHER" },
+    ];
+
+    // ============================================================= reactive
+    const form = reactive<IForm>({
+      name: {
+        valid: false,
+        value: "",
+        rules: [
+          (v: string) => !!v || "Error.InputEmpty_Inputs.DeclarationName",
+          (v: string) => v.length >= 2 || "Error.InputMinLength_2",
+          (v: string) => v.length <= 256 || "Error.InputMaxLength_256",
+        ],
+      },
+      email: {
+        valid: false,
+        value: "",
+        rules: [
+          (v: string) => !!v || "Error.InputEmpty_Inputs.DeclarationEmail",
+          (v: string) => /.+@.+\..+/.test(v) || "Error.InputEmailForm",
+        ],
+      },
+      contract: {
+        valid: true,
+        value: "COINS",
+      },
+      details: {
+        valid: true,
+        value: "",
+        rules: [(v: string) => v.length <= 4096 || "Error.InputMaxLength_4096"],
+      },
+      submitting: false,
+      validate: () => {
+        let isValid = true;
+
+        for (const key in form) {
+          if (key != "validate" && key != "body" && key != "submitting" && !form[key].valid) {
+            isValid = false;
+          }
+        }
+
+        if (refForm.value) refForm.value.reportValidity();
+        return isValid;
+      },
+      body: () => {
+        const details = form.details.value.trim();
+
+        return {
+          name: form.name.value.trim(),
+          email: form.email.value.trim(),
+          contract: form.contract.value,
+          details: !!details ? details : null,
+        };
+      },
+    });
+
+    // ============================================================= computed
+    const receivedAt = computed(() =>
+      formatDeclarationDateTime(declaration.value?.received_at ?? "", locale.value)
+    );
+
+    const contractLabel = computed(
+      () => CONTRACT_LABELS[declaration.value?.contract] ?? "Inputs.ContractOther"
+    );
+
+    // ============================================================= prefill
+    // A logged in user gets name and e-mail filled in, but both stay editable
+    // and nothing on this page depends on a session.
+    const user = <any>useUser();
+
+    function prefillFromSession() {
+      const profile = user.value;
+      if (!!!profile) return;
+
+      const fullName = [profile.first_name, profile.last_name]
+        .map((part: string) => (part ?? "").trim())
+        .filter((part: string) => !!part)
+        .join(" ");
+
+      const name = fullName || profile.display_name || profile.name || "";
+
+      if (!!name && !!!form.name.value) form.name.value = name;
+      if (!!profile.email && !!!form.email.value) form.email.value = profile.email;
+    }
+
+    watch(user, prefillFromSession, { immediate: true });
+
+    // ============================================================= functions
+    async function onclickSubmitForm() {
+      if (!form.validate()) return openSnackbar("error", "Error.InvalidForm");
+
+      form.submitting = true;
+
+      const [success, error] = await declareWithdrawal(form.body());
+
+      form.submitting = false;
+
+      success ? successHandler(success) : errorHandler(error);
+    }
+
+    function successHandler(res: any) {
+      declaration.value = res?.declaration ?? res ?? null;
+      confirmationEmailSent.value = !!res?.confirmation_email_sent;
+
+      openSnackbar("success", "Success.WithdrawalDeclared");
+    }
+
+    function errorHandler(res: any) {
+      openSnackbar("error", declarationErrorKey(res));
+    }
+
+    function onclickPrint() {
+      window.print();
+    }
+
+    return {
+      t,
+      refForm,
+      form,
+      contracts,
+      declaration,
+      confirmationEmailSent,
+      receivedAt,
+      contractLabel,
+      onclickSubmitForm,
+      onclickPrint,
+    };
+  },
+});
+</script>
+
+<style scoped>
+/*
+  § 356a BGB: the printed sheet has to reproduce the declaration. The
+  navigation, the language switcher, the footer, the permanent bar and the
+  print button are hidden by a `print:` utility, so only this page remains -
+  in black on white, because the interface itself is a dark theme.
+*/
+@media print {
+  main,
+  main :deep(*) {
+    color: #000 !important;
+    background: transparent !important;
+  }
+}
+</style>


### PR DESCRIPTION
Adds the two statutory declaration routes and makes them reachable from every page without logging in. Companion to Bootstrap-Academy/backend#723.

## Pages

| Route | Purpose | Submit button |
| --- | --- | --- |
| `/vertrag-kuendigen` | cancellation of a contract (§ 312k BGB) | „jetzt kündigen" / "cancel now" |
| `/vertrag-widerrufen` | withdrawal from a contract (§ 356a BGB) | „jetzt widerrufen" / "withdraw now" |

Both are public: no middleware, no session required. The cancellation form asks for the type of cancellation (ordinary / extraordinary with an optional reason), name, e-mail address, the contract and either the next possible date or a chosen end date. The withdrawal form asks for name, e-mail address, the contract or order and optional order details. Logged in users get name and e-mail prefilled; the fields stay editable.

## Permanent buttons

`components/ContractTermination.vue` renders „Verträge hier kündigen" / "Cancel contracts here" and „Vertrag widerrufen" / "Withdraw from contract". It is placed in `app.vue` right after `<NuxtPage />`, inside `<NuxtLayout>`, so it lands in the slot of every layout — `default`, `inner`, `empty` and `errorLayout` alike — and therefore appears on every route, including the ones without a footer. `error.vue` renders it as well, because `app.vue` is not used for the error page. Both routes are additionally linked from the footer.

## Record of the declaration

After a successful submission the form is replaced by a record showing the date and time of receipt in `Europe/Berlin`, the full content of the declaration, the end of the contract when the API returns one, the declaration reference and whether the confirmation e-mail was sent. A „Als PDF speichern / Drucken" action calls `window.print()`; a print stylesheet reduces the printed page to the record by hiding the language switcher, the navigation, the footer, the button bar and the print button itself.

## Subscription page

The unchanged automatic renewal toggle is joined by a link to `/vertrag-kuendigen`, shown whether or not a period is currently running — switching the renewal off is not a cancellation.

## Locales

All new strings are in `locales/de.json` and `locales/en-US.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
