### PR TITLE
Ask for the withdrawal declarations before every paid order

### DIFF
--- a/components/calendar/EventBooking.vue
+++ b/components/calendar/EventBooking.vue
@@ -59,6 +59,7 @@
         <OrderSummary
           :coins="price"
           :heading="btn"
+          :disabled="!canBook"
           :submit-label="price > 0 ? 'Buttons.OrderWithObligationToPay' : bookLabel"
           class="w-full"
           @order="onclickBook"
@@ -68,21 +69,12 @@
           </template>
 
           <template #consent>
-            <InputCheckbox
-              id="RightToWithdrawal"
-              label="Links.RightToWithdrawal"
-              :link="{
-                to: '/docs/right-of-withdrawal',
-                label: 'Links.RightToWithdrawalLink',
-              }"
-              target="_blank"
-              v-model="confirmRightToWithdrawal"
-            />
-            <InputCheckbox
-              id="DontUseRightToWithdrawal"
-              label="Links.DontUseRightToWithdrawal"
-              v-model="confirmDontUseRightToWithdrawal"
-            />
+            <!--
+              Webinars and coachings are services, so a paid booking needs the
+              declarations of § 356 Abs. 5 Nr. 2 BGB. A free event is not
+              booked against payment, so they are not asked for.
+            -->
+            <OrderWithdrawalConsent v-if="price > 0" kind="service" v-model="withdrawalConsent" />
           </template>
 
           <template #actions>
@@ -149,21 +141,39 @@ const isEventBooked = ref(props.booked ?? false);
 
 const dialog = <any>reactive({});
 const confirm = ref(false);
-const confirmRightToWithdrawal = ref(false);
-const confirmDontUseRightToWithdrawal = ref(false);
+const withdrawalConsent = ref(false);
 const information = ref(false);
 
+const canBook = computed(() => price.value <= 0 || withdrawalConsent.value);
+
 function onclickConfirm() {
+  // The dialog is rebuilt every time it opens, so the boxes start unticked.
+  withdrawalConsent.value = false;
   confirm.value = true;
 }
 
 async function onclickBook() {
-  if (!confirmRightToWithdrawal.value || !confirmDontUseRightToWithdrawal.value) {
+  if (!canBook.value) {
     openSnackbar("error", "Error.MustAgreeToBothPointsInOrderToMoveForward");
     return;
   }
 
   setLoading(true);
+
+  // Bookings are placed against the events service, which does not store the
+  // declarations, so they are recorded here first.
+  if (price.value > 0) {
+    const [, consentError] = await recordWithdrawalConsent(
+      props.type === "coaching" ? "coaching" : "webinar",
+      props.id
+    );
+    if (consentError) {
+      setLoading(false);
+      openSnackbar("error", consentError?.detail ?? "Error.WithdrawalConsentMissing");
+      return;
+    }
+  }
+
   switch (props.type) {
     case "coaching":
       await bookCoaching();
@@ -172,8 +182,7 @@ async function onclickBook() {
       await bookWebinar();
       break;
   }
-  confirmRightToWithdrawal.value = false;
-  confirmDontUseRightToWithdrawal.value = false;
+  withdrawalConsent.value = false;
   setLoading(false);
   confirm.value = false;
 }

--- a/components/course/Overview.vue
+++ b/components/course/Overview.vue
@@ -58,6 +58,7 @@
         <OrderSummary
           :coins="price"
           :loading="loading"
+          :disabled="!canOrder"
           :submit-label="price > 0 ? 'Buttons.OrderWithObligationToPay' : 'Buttons.EnrollNow'"
           @order="onclickOrder"
         >
@@ -78,21 +79,12 @@
               v-model="termsAndConditions"
             />
 
-            <InputCheckbox
-              label="Links.RightToWithdrawal"
-              id="RightToWithdrawal"
-              :link="{
-                to: '/docs/right-of-withdrawal',
-                label: 'Links.RightToWithdrawalLink',
-              }"
-              target="_blank"
-              v-model="confirmRightToWithdrawal"
-            />
-            <InputCheckbox
-              label="Links.DontUseRightToWithdrawal"
-              id="DontUseRightToWithdrawal"
-              v-model="confirmDontUseRightToWithdrawal"
-            />
+            <!--
+              A paid course is digital content, so the declarations of
+              § 356 Abs. 6 Nr. 2 BGB are required. A free course is not
+              ordered against payment, so they are not asked for.
+            -->
+            <OrderWithdrawalConsent v-if="price > 0" kind="digital" v-model="withdrawalConsent" />
           </template>
 
           <template #actions>
@@ -134,8 +126,7 @@ const snackbar = useSnackbar();
 const router = useRouter();
 
 const termsAndConditions = ref(false);
-const confirmRightToWithdrawal = ref(false);
-const confirmDontUseRightToWithdrawal = ref(false);
+const withdrawalConsent = ref(false);
 const confirming = ref(false);
 
 function onclickEnroll() {
@@ -144,15 +135,14 @@ function onclickEnroll() {
     return;
   }
 
+  // The dialog is rebuilt every time it opens, so the boxes start unticked.
+  termsAndConditions.value = false;
+  withdrawalConsent.value = false;
   confirming.value = true;
 }
 
 async function onclickOrder() {
-  if (
-    !termsAndConditions.value ||
-    !confirmRightToWithdrawal.value ||
-    !confirmDontUseRightToWithdrawal.value
-  ) {
+  if (!canOrder.value) {
     snackbar.value = {
       show: true,
       type: "error",
@@ -163,6 +153,22 @@ async function onclickOrder() {
   }
 
   loading.value = true;
+
+  // Courses are unlocked by the skills service, which does not store the
+  // declarations, so they are recorded here before the order is placed.
+  if (price.value > 0) {
+    const [, consentError] = await recordWithdrawalConsent("course", props.data?.id ?? "");
+    if (consentError) {
+      loading.value = false;
+      snackbar.value = {
+        show: true,
+        type: "error",
+        heading: consentError?.detail ?? "Error.WithdrawalConsentMissing",
+        body: "",
+      };
+      return;
+    }
+  }
 
   const [success, error] = await enrollIntoCourse(props.data?.id ?? "");
   if (success) await getCourseByID(props.data?.id ?? "");
@@ -185,6 +191,10 @@ async function onclickOrder() {
 const price = computed(() => {
   return props.data?.price ?? 0;
 });
+
+const canOrder = computed(
+  () => termsAndConditions.value && (price.value <= 0 || withdrawalConsent.value)
+);
 
 const totalSections = computed(() => {
   let sections = props.data?.sections ?? 0;

--- a/components/form/BuyCoins.vue
+++ b/components/form/BuyCoins.vue
@@ -73,26 +73,6 @@
       @valid="form.termsAndConditions.valid = $event"
     />
 
-    <InputCheckbox
-      class="mb-card"
-      label="Links.RightToWithdrawal"
-      id="RightToWithdrawal"
-      :link="{
-        to: '/docs/right-of-withdrawal',
-        label: 'Links.RightToWithdrawalLink',
-      }"
-      target="_blank"
-      v-model="form.confirmRightToWithdrawal.value"
-      @valid="form.confirmRightToWithdrawal.valid = $event"
-    />
-    <InputCheckbox
-      class="mb-card"
-      id="DontUseRightToWithdrawal"
-      label="Links.DontUseRightToWithdrawal"
-      v-model="form.confirmDontUseRightToWithdrawal.value"
-      @valid="form.confirmDontUseRightToWithdrawal.valid = $event"
-    />
-
     <Btn
       full
       @click="onclickSubmitForm"
@@ -135,14 +115,6 @@ export default defineComponent({
         value: 500,
       },
       termsAndConditions: {
-        value: false,
-        valid: false,
-      },
-      confirmRightToWithdrawal: {
-        value: false,
-        valid: false,
-      },
-      confirmDontUseRightToWithdrawal: {
         value: false,
         valid: false,
       },

--- a/components/order/Summary.vue
+++ b/components/order/Summary.vue
@@ -60,8 +60,9 @@
       <slot name="actions" />
       <InputBtn
         :loading="loading"
+        :aria-disabled="disabled"
         :class="{ 'pointer-events-none opacity-70': disabled }"
-        @click="$emit('order')"
+        @click="onclickOrder"
       >
         {{ t(submitLabel) }}
       </InputBtn>
@@ -90,7 +91,14 @@ const props = defineProps({
   submitLabel: { type: String, default: "Buttons.OrderWithObligationToPay" },
 });
 
-defineEmits<{ (e: "order"): void }>();
+const emit = defineEmits<{ (e: "order"): void }>();
+
+// The order must not be placeable while something is still missing, no matter
+// how the button is activated.
+function onclickOrder() {
+  if (props.disabled || props.loading) return;
+  emit("order");
+}
 
 const { t, locale } = useI18n();
 const config = useCoinConfig();

--- a/components/order/WithdrawalConsent.vue
+++ b/components/order/WithdrawalConsent.vue
@@ -1,0 +1,52 @@
+<!--
+  The declarations a consumer has to give before a paid order can be placed
+  (§ 356 Abs. 5 Nr. 2 BGB for services, § 356 Abs. 6 Nr. 2 BGB for digital
+  content). Both boxes are unticked by default and the order button stays
+  disabled until both are ticked.
+
+  The wording is taken verbatim from the withdrawal instruction on
+  `/docs/right-of-withdrawal` and is therefore identical in both locales: the
+  contract language is German.
+-->
+<template>
+  <div class="grid gap-box">
+    <p v-if="locale !== 'de'" class="text-body-2 m-0 text-body">
+      {{ t("Body.WithdrawalConsentLanguageNote") }}
+    </p>
+
+    <InputCheckbox
+      id="WithdrawalConsentPerformance"
+      :label="`Body.WithdrawalConsent${part}Performance`"
+      v-model="performance"
+    />
+
+    <InputCheckbox
+      id="WithdrawalConsentLoss"
+      :label="`Body.WithdrawalConsent${part}Loss`"
+      v-model="loss"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import type { WithdrawalKind } from "~~/composables/withdrawal";
+
+const props = defineProps({
+  /** Which part of the withdrawal instruction applies to this order. */
+  kind: { type: String as PropType<WithdrawalKind>, default: "digital" },
+  /** `true` once both declarations have been given. */
+  modelValue: { type: Boolean, default: false },
+});
+
+const emit = defineEmits<{ (e: "update:modelValue", value: boolean): void }>();
+
+const { t, locale } = useI18n();
+
+const performance = ref(false);
+const loss = ref(false);
+
+const part = computed(() => (props.kind === "service" ? "Service" : "Digital"));
+
+watch([performance, loss], ([a, b]) => emit("update:modelValue", a && b));
+</script>

--- a/components/user/RefillHeartBtn.vue
+++ b/components/user/RefillHeartBtn.vue
@@ -14,11 +14,20 @@
 
   <Modal v-if="ordering" @backdrop="ordering = false">
     <div class="w-full max-w-2xl bg-secondary p-8 style-card">
-      <OrderSummary :coins="refillPrice" :loading="loading" @order="confirmOrder">
+      <OrderSummary
+        :coins="refillPrice"
+        :loading="loading"
+        :disabled="!withdrawalConsent"
+        @order="confirmOrder"
+      >
         <template #characteristics>
           <p class="text-body-1 m-0 text-body">
             {{ t("Body.OrderHeartsCharacteristics", { max: maxHearts }) }}
           </p>
+        </template>
+
+        <template #consent>
+          <OrderWithdrawalConsent kind="digital" v-model="withdrawalConsent" />
         </template>
 
         <template #actions>
@@ -40,6 +49,9 @@ export default {
     const heartConfig = useHeartConfig();
     const ordering = ref(false);
     const loading = ref(false);
+    // Hearts are digital content, so the declarations of § 356 Abs. 6 Nr. 2
+    // BGB are required before the refill is ordered.
+    const withdrawalConsent = ref(false);
 
     const hearts = computed(() => {
       return heartInfo.value?.hearts ?? 0;
@@ -59,21 +71,35 @@ export default {
         });
       }
 
+      // The dialog is rebuilt every time it opens, so the boxes start unticked.
+      withdrawalConsent.value = false;
       ordering.value = true;
     }
 
     async function confirmOrder() {
       if (loading.value) return;
+      if (!withdrawalConsent.value) {
+        return openSnackbar("error", "Error.WithdrawalConsentMissing");
+      }
 
       loading.value = true;
-      const [success] = await refillHearts();
+      const [success] = await refillHearts(withdrawalConsentBody());
       loading.value = false;
       ordering.value = false;
 
       if (success) openSnackbar("success", "Success.RefilledHearts");
     }
 
-    return { t, fnRefillHearts, confirmOrder, ordering, loading, refillPrice, maxHearts };
+    return {
+      t,
+      fnRefillHearts,
+      confirmOrder,
+      ordering,
+      loading,
+      withdrawalConsent,
+      refillPrice,
+      maxHearts,
+    };
   },
 };
 </script>

--- a/composables/fetch.js
+++ b/composables/fetch.js
@@ -178,6 +178,8 @@ const onResponseError = async (context) => {
     return (response._data.detail = "Error.NoCourseAccess");
   } else if (details.includes("not enough coins")) {
     return (response._data.detail = "Error.NotEnoughCoins");
+  } else if (details.includes("withdrawal consent missing")) {
+    return (response._data.detail = "Error.WithdrawalConsentMissing");
   } else if (details.includes("cannot start in the past")) {
     return (response._data.detail = "Error.CannotStartInPast");
   } else if (details.includes("too many requests")) {

--- a/composables/hearts.ts
+++ b/composables/hearts.ts
@@ -1,9 +1,14 @@
 export const useHeartInfo = () => useState("heartInfo", () => null);
 
-/** Refill the hearts to the maximum for `hearts_refill_price` Morphcoins. */
-export async function refillHearts() {
+/**
+ * Refill the hearts to the maximum for `hearts_refill_price` Morphcoins.
+ *
+ * The body carries the declarations of § 356 Abs. 6 Nr. 2 BGB; without them
+ * the refill is refused.
+ */
+export async function refillHearts(body: any) {
   try {
-    const res = await PUT(`/shop/hearts`);
+    const res = await PUT(`/shop/hearts`, body);
     await getHearts();
     await getBalance();
     return [res, null];

--- a/composables/withdrawal.ts
+++ b/composables/withdrawal.ts
@@ -1,0 +1,48 @@
+/**
+ * The declarations a consumer has to give before a paid order can be placed so
+ * that the right of withdrawal expires early (§ 356 Abs. 5 Nr. 2 / Abs. 6
+ * Nr. 2 BGB).
+ *
+ * The wording is fixed by the withdrawal instruction on
+ * `/docs/right-of-withdrawal`; part A applies to services (premium, webinars,
+ * coachings), part B to digital content (Morphcoins, courses, hearts). Both
+ * the version below and the declarations themselves have to be changed
+ * together with that page.
+ */
+
+/** Version of the withdrawal instruction the declarations are taken from. */
+export const WITHDRAWAL_TEXT_VERSION = "2026-09";
+
+/** Which part of the withdrawal instruction applies to an order. */
+export type WithdrawalKind = "service" | "digital";
+
+/** Purchases the declarations are recorded for. */
+export type WithdrawalSubject = "coins" | "premium" | "hearts" | "course" | "webinar" | "coaching";
+
+/** Body every order request carries once the declarations have been given. */
+export function withdrawalConsentBody() {
+  return {
+    withdrawal_consent: true,
+    withdrawal_text_version: WITHDRAWAL_TEXT_VERSION,
+  };
+}
+
+/**
+ * Record the declarations for an order that is placed against one of the other
+ * services (course unlock, webinar and coaching bookings). Those services do
+ * not store the declarations themselves, so they are recorded here first and
+ * the order is only placed if that succeeded.
+ */
+export async function recordWithdrawalConsent(subject: WithdrawalSubject, reference?: string) {
+  try {
+    const response = await POST(`/shop/consents`, {
+      subject,
+      reference: reference || null,
+      ...withdrawalConsentBody(),
+    });
+
+    return [response, null];
+  } catch (error: any) {
+    return [null, error.data];
+  }
+}

--- a/locales/de.json
+++ b/locales/de.json
@@ -513,7 +513,12 @@
     "NoContractFoundForEmail": "Den Zeitpunkt, zu dem der Vertrag endet, können wir zu Ihren Angaben nicht automatisch ermitteln. Wir prüfen Ihre Kündigung und bestätigen Ihnen den Beendigungszeitpunkt gesondert per E-Mail.",
     "ConfirmationEmailSent": "Eine Bestätigung mit diesem Inhalt haben wir Ihnen soeben per E-Mail an {email} geschickt.",
     "ConfirmationEmailNotSent": "Die Bestätigungs-E-Mail konnte nicht zugestellt werden. Bitte speichern oder drucken Sie diese Seite.",
-    "CancelPremiumHint": "Dort können Sie Ihre Premium-Mitgliedschaft mit dem gesetzlichen Kündigungsformular kündigen; den Eingang bestätigen wir Ihnen sofort per E-Mail."
+    "CancelPremiumHint": "Dort können Sie Ihre Premium-Mitgliedschaft mit dem gesetzlichen Kündigungsformular kündigen; den Eingang bestätigen wir Ihnen sofort per E-Mail.",
+    "WithdrawalConsentLanguageNote": "Die folgenden Erklärungen sind Teil des Vertrags und daher nur auf Deutsch verfügbar.",
+    "WithdrawalConsentServicePerformance": "Ich verlange ausdrücklich und stimme zu, dass Sie vor Ablauf der Widerrufsfrist mit der Erbringung der Dienstleistung beginnen.",
+    "WithdrawalConsentServiceLoss": "Mir ist bekannt, dass mein Widerrufsrecht mit vollständiger Erbringung der Dienstleistung erlischt.",
+    "WithdrawalConsentDigitalPerformance": "Ich stimme ausdrücklich zu, dass Sie vor Ablauf der Widerrufsfrist mit der Ausführung des Vertrags beginnen.",
+    "WithdrawalConsentDigitalLoss": "Mir ist bekannt, dass mein Widerrufsrecht mit Beginn der Ausführung des Vertrags erlischt."
   },
   "AltAttributes": {
     "BootstrapAcademyLogo": "Bootstrap Academy Logo",
@@ -951,7 +956,6 @@
     "GoToProfile": "Zum Profil",
     "RightToWithdrawal": "Dir steht ein 14-tägiges Widerrufsrecht zu. Widerrufsbelehrung + Widerrufsformular findest du",
     "RightToWithdrawalLink": "hier",
-    "DontUseRightToWithdrawal": "Ich verlange, dass die Dienstleister vor Ende der Widerrufsfrist mit der in Auftrag gegebenen Dienstleistung beginnen.",
     "VideoPrivacyHint": "Beim Abspielen werden Daten an YouTube (Google) übertragen. Details in unseren",
     "OrderLegalHint": "Es gelten unsere",
     "OrderLegalHintMiddle": "und die",
@@ -1132,7 +1136,8 @@
     "ProviderNotFound": "Dieser Anbieter kann nicht gefunden werden.",
     "InvalidCoinAmount": "Ungültige Anzahl an Morphcoins. Bitte starte den Kauf erneut.",
     "TooManyRequests": "Zu viele Anfragen. Bitte versuchen Sie es später erneut oder schreiben Sie uns an hallo{'@'}bootstrap.academy.",
-    "DeclarationNotSubmitted": "Ihre Erklärung konnte nicht übermittelt werden. Bitte versuchen Sie es erneut oder senden Sie Ihre Erklärung an hallo{'@'}bootstrap.academy."
+    "DeclarationNotSubmitted": "Ihre Erklärung konnte nicht übermittelt werden. Bitte versuchen Sie es erneut oder senden Sie Ihre Erklärung an hallo{'@'}bootstrap.academy.",
+    "WithdrawalConsentMissing": "Bitte gib die beiden Erklärungen zum Widerrufsrecht ab, um zu bestellen"
   },
   "Months": {
     "January": "Januar",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -514,7 +514,12 @@
     "NoContractFoundForEmail": "We cannot determine the end of the contract automatically from your details. We will review your cancellation and confirm the end date separately by e-mail.",
     "ConfirmationEmailSent": "We have just sent you a confirmation with this content by e-mail to {email}.",
     "ConfirmationEmailNotSent": "The confirmation e-mail could not be delivered. Please save or print this page.",
-    "CancelPremiumHint": "There you can cancel your premium membership with the statutory cancellation form; we confirm the receipt by e-mail immediately."
+    "CancelPremiumHint": "There you can cancel your premium membership with the statutory cancellation form; we confirm the receipt by e-mail immediately.",
+    "WithdrawalConsentLanguageNote": "The following declarations are part of the contract. The contract language is German, so they are shown in German only.",
+    "WithdrawalConsentServicePerformance": "Ich verlange ausdrücklich und stimme zu, dass Sie vor Ablauf der Widerrufsfrist mit der Erbringung der Dienstleistung beginnen.",
+    "WithdrawalConsentServiceLoss": "Mir ist bekannt, dass mein Widerrufsrecht mit vollständiger Erbringung der Dienstleistung erlischt.",
+    "WithdrawalConsentDigitalPerformance": "Ich stimme ausdrücklich zu, dass Sie vor Ablauf der Widerrufsfrist mit der Ausführung des Vertrags beginnen.",
+    "WithdrawalConsentDigitalLoss": "Mir ist bekannt, dass mein Widerrufsrecht mit Beginn der Ausführung des Vertrags erlischt."
   },
   "AltAttributes": {
     "BootstrapAcademyLogo": "Bootstrap Academy logo",
@@ -953,7 +958,6 @@
     "GoToCourse": "Go To Course",
     "RightToWithdrawal": "You have a 14-day right of withdrawal. You will find the cancellation policy + cancellation form",
     "RightToWithdrawalLink": "here",
-    "DontUseRightToWithdrawal": "I request that you start the commissioned service before the end of the cancellation period.",
     "VideoPrivacyHint": "Playing the video sends data to YouTube (Google). Details are in our",
     "OrderLegalHint": "Our",
     "OrderLegalHintMiddle": "and our",
@@ -1134,7 +1138,8 @@
     "ProviderNotFound": "Unable to find this provider. Please select another one.",
     "InvalidCoinAmount": "Invalid number of Morphcoins. Please start the purchase again.",
     "TooManyRequests": "Too many requests. Please try again later or write to us at hallo{'@'}bootstrap.academy.",
-    "DeclarationNotSubmitted": "Your declaration could not be submitted. Please try again or send your declaration to hallo{'@'}bootstrap.academy."
+    "DeclarationNotSubmitted": "Your declaration could not be submitted. Please try again or send your declaration to hallo{'@'}bootstrap.academy.",
+    "WithdrawalConsentMissing": "Please give both withdrawal declarations to place the order"
   },
   "Months": {
     "January": "January",

--- a/pages/morphcoins/paypal.vue
+++ b/pages/morphcoins/paypal.vue
@@ -146,7 +146,7 @@
         <OrderSummary
           :coins="coinsToBuy"
           breakdown
-          :disabled="!canBuy"
+          :disabled="!canBuy || !withdrawalConsent"
           :hide-actions="ordered"
           @order="onclickOrder"
         >
@@ -154,6 +154,10 @@
             <p class="text-body-1 m-0 text-body">
               {{ t("Body.OrderCoinsCharacteristics") }}
             </p>
+          </template>
+
+          <template #consent>
+            <OrderWithdrawalConsent kind="digital" v-model="withdrawalConsent" />
           </template>
         </OrderSummary>
       </article>
@@ -220,6 +224,9 @@ export default {
 
     const paypal = ref(null);
     const ordered = ref(false);
+    // Morphcoins are digital content, so the declarations of § 356 Abs. 6
+    // Nr. 2 BGB have to be given before the order can be placed.
+    const withdrawalConsent = ref(false);
     const paypalClientID = usePaypalClientID();
 
     onMounted(loadCoinConfig);
@@ -228,6 +235,10 @@ export default {
     // requested only from here (§ 25 Abs. 2 Nr. 2 TDDDG).
     async function onclickOrder() {
       if (!validAmount.value || !canBuy.value) return;
+      if (!withdrawalConsent.value) {
+        openSnackbar("error", "Error.WithdrawalConsentMissing");
+        return;
+      }
 
       setLoading(true);
       await getPaypalClientID();
@@ -244,7 +255,10 @@ export default {
     }
 
     function renderPaypalButtons() {
-      const orderBody = JSON.stringify({ coins: coinsToBuy.value });
+      const orderBody = JSON.stringify({
+        coins: coinsToBuy.value,
+        ...withdrawalConsentBody(),
+      });
 
       const script = document.createElement("script");
       script.setAttribute("data-namespace", "paypal_sdk");
@@ -298,6 +312,7 @@ export default {
       canBuy,
       paypal,
       ordered,
+      withdrawalConsent,
       onclickOrder,
     };
   },

--- a/pages/subscription/index.vue
+++ b/pages/subscription/index.vue
@@ -115,7 +115,12 @@
     -->
     <Modal v-if="order" @backdrop="order = null">
       <div class="w-full max-w-2xl bg-secondary p-8 style-card">
-        <OrderSummary :coins="order.coins" :loading="ordering" @order="confirmOrder">
+        <OrderSummary
+          :coins="order.coins"
+          :loading="ordering"
+          :disabled="!withdrawalConsent"
+          @order="confirmOrder"
+        >
           <template #characteristics>
             <p class="text-body-1 m-0 text-body">{{ t(order.characteristics, order.params) }}</p>
 
@@ -128,6 +133,10 @@
                 <dd class="text-body-1 m-0 text-heading">{{ t(detail.value) }}</dd>
               </template>
             </dl>
+          </template>
+
+          <template #consent>
+            <OrderWithdrawalConsent :kind="order.consentKind" v-model="withdrawalConsent" />
           </template>
 
           <template #actions>
@@ -211,6 +220,8 @@ export default {
     // The pending order shown in the order summary, or `null`.
     const order = ref<any>(null);
     const ordering = ref(false);
+    // The declarations of § 356 Abs. 5/6 BGB for the pending order.
+    const withdrawalConsent = ref(false);
 
     function subscribe(isYearly: boolean) {
       const plan = isYearly ? "YEARLY" : "MONTHLY";
@@ -225,8 +236,11 @@ export default {
       // configured; a first purchase never enables it.
       const renews = !!premiumStatusAutoPay.value;
 
+      withdrawalConsent.value = false;
       order.value = {
         coins: coinsRequired,
+        // Premium is a service (part A of the withdrawal instruction).
+        consentKind: "service",
         characteristics: "Body.OrderPremiumCharacteristics",
         params: {},
         details: [
@@ -240,7 +254,11 @@ export default {
           },
         ],
         submit: async () => {
-          const [success] = await buyPremium({ plan, autopay: renews });
+          const [success] = await buyPremium({
+            plan,
+            autopay: renews,
+            ...withdrawalConsentBody(),
+          });
           if (success) {
             openSnackbar(
               "success",
@@ -253,6 +271,10 @@ export default {
 
     async function confirmOrder() {
       if (!order.value || ordering.value) return;
+      if (!withdrawalConsent.value) {
+        openSnackbar("error", "Error.WithdrawalConsentMissing");
+        return;
+      }
 
       ordering.value = true;
       try {
@@ -260,6 +282,7 @@ export default {
       } finally {
         ordering.value = false;
         order.value = null;
+        withdrawalConsent.value = false;
       }
     }
 
@@ -272,13 +295,16 @@ export default {
         });
       }
 
+      withdrawalConsent.value = false;
       order.value = {
         coins: refillPrice.value,
+        // Hearts are digital content (part B of the withdrawal instruction).
+        consentKind: "digital",
         characteristics: "Body.OrderHeartsCharacteristics",
         params: { max: formatHearts(heartConfig.value.hearts_max, locale.value) },
         details: [],
         submit: async () => {
-          const [success] = await refillHearts();
+          const [success] = await refillHearts(withdrawalConsentBody());
           if (success) openSnackbar("success", "Success.RefilledHearts");
         },
       };
@@ -323,6 +349,7 @@ export default {
       heartConfig,
       order,
       ordering,
+      withdrawalConsent,
       confirmOrder,
       monthlyPrice,
       yearlyPrice,


### PR DESCRIPTION
The order summary shown immediately before a paid order is placed now carries the two declarations a consumer has to give so that the right of withdrawal can expire early — the express request that performance begins before the withdrawal period ends (§ 356 Abs. 5 Nr. 2 BGB for services, § 356 Abs. 6 Nr. 2 BGB for digital content) and the acknowledgment that the right is lost as a result. Both boxes start unticked, and the "Zahlungspflichtig bestellen" button stays inactive until both are ticked.

## Wording

The two sentences are taken verbatim from the withdrawal instruction on `/docs/right-of-withdrawal`: part A for premium, webinars and coachings, part B for Morphcoins, courses and hearts. They are shown in German in both locales because the contract language is German; the English interface adds one line saying so. The old, differently worded single box (`Links.DontUseRightToWithdrawal`) is removed, and the two withdrawal boxes on the coin amount step move to the order summary, where the order is actually placed.

## Surfaces

| surface | part | how the declarations are sent |
| --- | --- | --- |
| coin purchase (`/morphcoins/paypal`) | B | with `POST /shop/coins/paypal/orders` |
| premium (`/subscription`) | A | with `POST /shop/premium` |
| heart refill (`/subscription`, challenge pages) | B | with `PUT /shop/hearts` |
| course unlock | B | `POST /shop/consents` before the unlock |
| webinar / coaching booking | A | `POST /shop/consents` before the booking |

Course unlocks and bookings are placed against the skills and events services, which do not store the declarations, so they are recorded through the new backend endpoint first and the order is only placed if that succeeded. Free courses and free events are not ordered against payment, so no declarations are asked for there.

Every order request carries `withdrawal_consent: true` and `withdrawal_text_version: "2026-09"` (`composables/withdrawal.ts`, the single place where the version lives).

## Verified

`npm run format:check`, `npm run lint` and `bash build.sh` are clean. The consent block was driven headlessly against a local backend: both declarations render verbatim, one ticked box is not enough, the order button does nothing while it is inactive, and the order goes through once both boxes are ticked.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
