### PR TITLE
feat: show the calendar subscription link and let users renew it

### DIFF
--- a/components/calendar/Features.vue
+++ b/components/calendar/Features.vue
@@ -14,9 +14,32 @@
       </h3>
     </article>
 
-    <a :href="ics" download type="text/calendar">
-      <Btn full class="mt-box">{{ t("Buttons.LinkCalendar") }}</Btn>
-    </a>
+    <section class="grid gap-3 mt-box">
+      <h2 class="text-heading-2">{{ t("Headings.CalendarSubscription") }}</h2>
+      <p class="text-body-2">{{ t("Body.CalendarSubscription") }}</p>
+
+      <div class="flex items-center gap-2">
+        <input
+          ref="urlInput"
+          class="text-body-2 w-full min-w-0 rounded border border-tertiary bg-primary px-3 py-2"
+          :value="ics"
+          :aria-label="t('Headings.CalendarSubscription')"
+          readonly
+          @focus="selectUrl"
+        />
+        <Btn sm secondary :disabled="!ics" @click="copy">
+          {{ copied ? t("Buttons.CalendarLinkCopied") : t("Buttons.CopyCalendarLink") }}
+        </Btn>
+      </div>
+
+      <a :href="ics" download type="text/calendar">
+        <Btn full>{{ t("Buttons.LinkCalendar") }}</Btn>
+      </a>
+
+      <Btn full secondary :disabled="!ics || rotating" @click="rotate">
+        {{ t("Buttons.RotateCalendarLink") }}
+      </Btn>
+    </section>
 
     <h2 class="text-heading-2 mt-card">{{ t("Headings.FilterBy") }}</h2>
 
@@ -33,6 +56,55 @@ export default defineComponent({
     const { t } = useI18n();
 
     const ics = useICS();
+
+    const urlInput = ref<HTMLInputElement | null>(null);
+    const copied = ref(false);
+    const rotating = ref(false);
+
+    function selectUrl(event: FocusEvent) {
+      (event.target as HTMLInputElement).select();
+    }
+
+    async function copy() {
+      try {
+        await navigator.clipboard.writeText(ics.value);
+      } catch {
+        // clipboard access can be denied; fall back to selecting the url so it
+        // can be copied by hand
+        urlInput.value?.select();
+        return;
+      }
+      copied.value = true;
+      setTimeout(() => (copied.value = false), 3000);
+    }
+
+    function rotate() {
+      openDialog(
+        "warning",
+        "Headings.RotateCalendarLink",
+        "Body.RotateCalendarLink",
+        false,
+        {
+          label: "Buttons.RotateCalendarLink",
+          onclick: async () => {
+            rotating.value = true;
+            const [response, error] = await rotateIcsToken();
+            rotating.value = false;
+
+            if (response) {
+              copied.value = false;
+              openSnackbar("success", "Success.RotateCalendarLink");
+            } else {
+              openSnackbar("error", error?.detail ?? "");
+            }
+          },
+        },
+        {
+          label: "Buttons.Cancel",
+          onclick: () => {},
+        }
+      );
+    }
 
     const coaching = reactive({
       label: "Headings.Coaching",
@@ -80,7 +152,19 @@ export default defineComponent({
         tooltip: "Body.MyEventsFilterToolTip",
       },
     ]);
-    return { t, types, eventFilter, eventFilterOptions, ics };
+    return {
+      t,
+      types,
+      eventFilter,
+      eventFilterOptions,
+      ics,
+      urlInput,
+      copied,
+      rotating,
+      selectUrl,
+      copy,
+      rotate,
+    };
   },
 });
 </script>

--- a/composables/calendar.ts
+++ b/composables/calendar.ts
@@ -6,6 +6,15 @@ export const useICS = () => useState("ics", () => "");
 export const useEvents = () => useState<(WebinarEvent | CoachingEvent)[]>("events", () => []);
 export const useEventFilter = () => useState("eventFilter", () => "all");
 
+/**
+ * The subscription url of the ics feed. The token in it is a bearer credential
+ * that is stored per user and can be replaced with `rotateIcsToken()`.
+ */
+function icsUrl(token: string) {
+  const config = useRuntimeConfig().public;
+  return token ? `${config.BASE_API_URL}/events/calendar/${token}/academy.ics` : "";
+}
+
 export async function getCalendar() {
   try {
     const response: Calendar = await GET(`/events/calendar`);
@@ -14,11 +23,28 @@ export async function getCalendar() {
     calendar.value = response ?? null;
 
     const ics = useICS();
-    const config = useRuntimeConfig().public;
-    ics.value = `${config.BASE_API_URL}/events/calendar/${response?.ics_token ?? ""}/academy.ics`;
+    ics.value = icsUrl(response?.ics_token ?? "");
 
     const events = useEvents();
     events.value = response?.events ?? [];
+
+    return [response, null];
+  } catch (error: any) {
+    return [null, error.data];
+  }
+}
+
+export async function rotateIcsToken() {
+  try {
+    const response: { ics_token: string } = await POST(`/events/calendar/token/rotate`);
+
+    const calendar = useCalendar();
+    if (calendar.value) {
+      calendar.value.ics_token = response?.ics_token ?? "";
+    }
+
+    const ics = useICS();
+    ics.value = icsUrl(response?.ics_token ?? "");
 
     return [response, null];
   } catch (error: any) {

--- a/locales/de.json
+++ b/locales/de.json
@@ -249,6 +249,8 @@
     "Rejected": "Abgelehnt",
     "MyCertificates": "Zertifikate",
     "EventTypes": "Event-Arten",
+    "CalendarSubscription": "Kalender-Abo",
+    "RotateCalendarLink": "Abo-Link erneuern?",
     "Coaching": "Coaching",
     "Exam": "Prüfung",
     "Webinar": "Webinar",
@@ -374,6 +376,8 @@
     "ContractTermination": "Vertragsbeendigung"
   },
   "Body": {
+    "CalendarSubscription": "Mit diesem Link abonnierst du deine Termine in einer Kalender-App. Wer den Link kennt, kann deine Termine lesen – teile ihn also nicht. Erneuerst du ihn, verlieren alle bisher eingerichteten Abos den Zugriff.",
+    "RotateCalendarLink": "Der bisherige Abo-Link wird sofort ungültig. Kalender-Apps, die ihn verwenden, erhalten keine Termine mehr, bis du den neuen Link dort einträgst.",
     "DashboardIntro": "Steig direkt wieder in deine Kurse oder Challenges ein.",
     "SkillTreeOverview": "Behalte deine Root-Skills im Blick und öffne die Details, wenn du tiefer einsteigen möchtest.",
     "SelectSkillDescription": "Wir müssen wissen, unter welchem Root-Skill du die Inhalte erstellen möchtest.",
@@ -850,6 +854,9 @@
     "Back": "Zurück",
     "Next": "Weiter",
     "LinkCalendar": "Kalender verknüpfen",
+    "CopyCalendarLink": "Link kopieren",
+    "CalendarLinkCopied": "Kopiert",
+    "RotateCalendarLink": "Abo-Link erneuern",
     "GoToShop": "ZUM SHOP",
     "ContactUs": "Schreib uns",
     "EnrollNow": "Jetzt anmelden",
@@ -969,6 +976,7 @@
     "WithdrawFromContract": "Vertrag widerrufen"
   },
   "Success": {
+    "RotateCalendarLink": "Neuer Abo-Link erstellt. Trage ihn in deiner Kalender-App ein.",
     "SolvedMatching": "Matching gelöst ✅",
     "DeleteMatching": "Matching erfolgreich gelöscht",
     "CreateMatching": "Matching erfolgreich erstellt",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -248,6 +248,8 @@
     "Rejected": "Rejected",
     "MyCertificates": "Certificates",
     "EventTypes": "Event Types",
+    "CalendarSubscription": "Calendar Subscription",
+    "RotateCalendarLink": "Create a new subscription link?",
     "Coaching": "Coaching",
     "Exam": "Exam",
     "Webinar": "Webinar",
@@ -374,6 +376,8 @@
     "ContractTermination": "Ending a contract"
   },
   "Body": {
+    "CalendarSubscription": "Subscribe to your events in a calendar app with this link. Anyone who knows the link can read your events, so do not share it. Creating a new one cuts off every subscription that uses the old link.",
+    "RotateCalendarLink": "The current subscription link stops working immediately. Calendar apps that use it will no longer receive your events until you enter the new link there.",
     "DashboardIntro": "Jump back into your courses or challenges to keep the momentum going.",
     "SkillTreeOverview": "Browse every root skill and open the details whenever you want to go deeper.",
     "SelectSkillDescription": "We need to know under which root skill you want to create the content.",
@@ -856,6 +860,9 @@
     "Back": "Back",
     "Next": "Next",
     "LinkCalendar": "Link Calendar",
+    "CopyCalendarLink": "Copy link",
+    "CalendarLinkCopied": "Copied",
+    "RotateCalendarLink": "New subscription link",
     "GoToShop": "Go To Shop",
     "ContactUs": "Contact Us",
     "EnrollNow": "Enroll Now",
@@ -971,6 +978,7 @@
     "WithdrawFromContract": "Withdraw from contract"
   },
   "Success": {
+    "RotateCalendarLink": "New subscription link created. Enter it in your calendar app.",
     "SolvedMatching": "Matching Solved ✅",
     "DeleteMatching": "Matching Delete Successfully",
     "CreateMatching": "Matching Created Successfully",


### PR DESCRIPTION
Frontend half of the revocable ics calendar token
(Bootstrap-Academy/events-ms#211).

## What

The subscription url of the calendar feed was only reachable through the
"Kalender verknüpfen" download button, and the token inside it was permanent —
derived from the user id and a server-wide secret, so it could not be revoked
for a single user. events-ms now stores a random token per user and offers
`POST /events/calendar/token/rotate`.

The calendar sidebar gains a "Kalender-Abo" section:

- the subscription url in a read-only field that selects itself on focus, with
  a copy button (falls back to selecting the text when clipboard access is
  denied),
- the existing download button, unchanged,
- **"Abo-Link erneuern"**, behind a confirmation dialog which says that every
  calendar app using the old link stops receiving events.

The short text above the field says what the link is, that whoever has it can
read the user's events, and what renewing does.

## Changes

- `composables/calendar.ts`: `rotateIcsToken()`; the url is built in one place
  (`icsUrl`) for both the initial load and the rotation.
- `components/calendar/Features.vue`: the new section, the copy action and the
  confirmation dialog.
- `locales/de.json`, `locales/en-US.json`: `Headings.CalendarSubscription`,
  `Headings.RotateCalendarLink`, `Body.CalendarSubscription`,
  `Body.RotateCalendarLink`, `Buttons.CopyCalendarLink`,
  `Buttons.CalendarLinkCopied`, `Buttons.RotateCalendarLink`,
  `Success.RotateCalendarLink`.

## Verified

`npm run format:check`, `npm run lint` and `npm run build` all pass locally.

## Order

Merge **after** the events-ms change is deployed — the rotate endpoint does not
exist before that, and the old hmac tokens stop being accepted with it, so
everyone has to copy the new url from this page once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
