### PR TITLE
Stop the profile card from crashing /profile

### DIFF
--- a/components/user/Profile.vue
+++ b/components/user/Profile.vue
@@ -89,7 +89,6 @@ export default {
 
     const showFreeQuizzesOnly = useAppCookie("showFreeQuizzesOnly");
     return {
-      image,
       username,
       nickname,
       description,


### PR DESCRIPTION
`components/user/Profile.vue` still returns `image` from its setup function, but the `image` computed was removed together with the Gravatar avatar in #711. The free identifier throws `ReferenceError: image is not defined` while the component sets up, so the component never renders and `/profile` shows the Nuxt error page with `500 Cannot read properties of undefined (reading 'icon')` instead of the profile card.

Reproduced against `origin/develop` with a local backend and a headless browser: logging in and opening `/profile` renders the 500 page; with the leftover entry removed the card renders again (initials avatar, nickname, display name, e-mail, registration month, premium button) and the page logs no errors.

Nothing reads the returned value — the avatar is drawn by `components/Avatar.vue` from the display name — so the fix is to drop the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)