### PR TITLE
Translate the required-checkbox message and mark the missing consent box

### DIFF
--- a/components/TermsGate.vue
+++ b/components/TermsGate.vue
@@ -47,6 +47,7 @@
           }"
           target="_blank"
           required
+          :show-error="attempted"
           v-model="termsAndConditions"
         />
 
@@ -54,6 +55,7 @@
           label="Links.MinimumAge"
           id="TermsGateMinimumAge"
           required
+          :show-error="attempted"
           v-model="ageConfirmed"
         />
       </div>
@@ -91,6 +93,10 @@ export default defineComponent({
     const submitting = ref(false);
     const declining = ref(false);
 
+    // Set once acceptance has been attempted, so an unticked box is pointed
+    // out next to itself and not only in the snackbar.
+    const attempted = ref(false);
+
     const show = computed(() => needsTermsAcceptance(route.path));
     const valid = computed(() => termsAndConditions.value && ageConfirmed.value);
 
@@ -112,6 +118,8 @@ export default defineComponent({
     );
 
     async function onclickAccept() {
+      attempted.value = true;
+
       if (!!!valid.value) {
         openSnackbar("error", "Error.InvalidForm");
         return;
@@ -146,6 +154,7 @@ export default defineComponent({
       bodyParts,
       submitting,
       declining,
+      attempted,
       termsAndConditions,
       ageConfirmed,
       onclickAccept,

--- a/components/form/Signup.vue
+++ b/components/form/Signup.vue
@@ -45,6 +45,7 @@
       }"
       target="_blank"
       required
+      :show-error="submitted"
       v-model="form.termsAndConditions.value"
       @valid="form.termsAndConditions.valid = $event"
     />
@@ -53,6 +54,7 @@
       label="Links.MinimumAge"
       id="MinimumAge"
       required
+      :show-error="submitted"
       v-model="form.ageConfirmed.value"
       @valid="form.ageConfirmed.valid = $event"
     />
@@ -87,6 +89,10 @@ export default defineComponent({
 
     // ============================================================= refs
     const refForm = ref<HTMLFormElement | null>(null);
+
+    // Set once the form has been submitted, so that the consent boxes point
+    // themselves out instead of the button doing nothing.
+    const submitted = ref(false);
 
     // ============================================================= reactive
     const form = reactive<IForm>({
@@ -194,6 +200,8 @@ export default defineComponent({
 
     // ============================================================= functions
     async function onclickSubmitForm() {
+      submitted.value = true;
+
       if (form.validate()) {
         form.submitting = true;
 
@@ -242,6 +250,7 @@ export default defineComponent({
       form,
       onclickSubmitForm,
       refForm,
+      submitted,
       t,
       register_token,
     };

--- a/components/input/Checkbox.vue
+++ b/components/input/Checkbox.vue
@@ -39,7 +39,7 @@
       class="relative z-0 pt-2 text-xs text-error transition duration-500 ease-out"
       :class="error ? 'translate-y-0 opacity-100' : 'translate-y-[-100%] opacity-0'"
     >
-      {{ error }}.
+      {{ error ? $t(error) : "" }}.
     </p>
   </article>
 </template>
@@ -56,6 +56,12 @@ export default defineComponent({
     target: { type: String, default: "" },
     id: { type: String, default: "" },
     required: { type: Boolean, default: false },
+    /**
+     * Show the "this is required" message even though the box has never been
+     * touched. Forms set this after a submit that was refused, so that a
+     * required box the user simply left alone is pointed out.
+     */
+    showError: { type: Boolean, default: false },
     label: { type: String, default: "" },
     link: {
       type: Object as PropType<{ to: string; label: string }>,
@@ -65,20 +71,28 @@ export default defineComponent({
   },
   emits: ["update:modelValue", "valid"],
   setup(props, { emit }) {
+    // ============================================================= refs
+    const touched = ref(false);
+
     // ============================================================= computed
     const input = computed({
       get() {
         return props.modelValue;
       },
       set(value) {
+        touched.value = true;
         emit("update:modelValue", value);
-        error.value = value ? "" : "This is required";
-        emit("valid", !!!error.value);
+        emit("valid", !!value);
       },
     });
 
-    // ============================================================= refs
-    const error = ref("");
+    // The message stays hidden until the user has touched the box or the form
+    // asked for it, so an untouched form does not start out red.
+    const error = computed(() =>
+      props.required && !props.modelValue && (touched.value || props.showError)
+        ? "Error.CheckboxRequired"
+        : ""
+    );
 
     // ============================================================= functions
     return { input, error };

--- a/locales/de.json
+++ b/locales/de.json
@@ -1085,6 +1085,7 @@
     "NoLecturesAvailable": "Keine Vorlesungen vorhanden",
     "NoDescriptionAvailable": "Keine Beschreibung verfügbar",
     "VerifyEmail": "Konto konnte nicht bestätigt werden. Versuche es später noch einmal",
+    "CheckboxRequired": "Bitte bestätige diesen Punkt",
     "InputCodeFormat": "Ungültiges Codeformat",
     "InputEmpty": "{placeholder} ist erforderlich",
     "InputMinLength": "Muss {placeholder} oder mehr Zeichen sein",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -1087,6 +1087,7 @@
     "NoLecturesAvailable": "No lectures available",
     "NoDescriptionAvailable": "No description available",
     "VerifyEmail": "Unable to verify account. Try again later",
+    "CheckboxRequired": "Please confirm this point",
     "InputCodeFormat": "Invalid code format",
     "InputEmpty": "{placeholder} is required",
     "InputMinLength": "Must {placeholder} or more characters",


### PR DESCRIPTION
Two defects on the consent boxes, found while driving the signup form and the terms gate in a headless browser against a local backend.

1. `components/input/Checkbox.vue` wrote the hard coded English string `"This is required"` into its error message. On the German signup form and the German terms gate the box therefore reads `This is required.` — the only untranslated string on either surface.

2. The message was only ever assigned inside the setter of the model, so it appeared exclusively after the box had been ticked and unticked again. A visitor who simply leaves the terms box and the age box alone and presses `ACCOUNT ERSTELLEN` gets the generic `Bitte füll das Formular korrekt aus.` snackbar, while none of the six fields is marked — the two boxes that actually block the submit look no different from the four that are fine.

The message is now the locale key `Error.CheckboxRequired` ("Bitte bestätige diesen Punkt" / "Please confirm this point") and is derived from the model plus a new `show-error` prop. `components/form/Signup.vue` and `components/TermsGate.vue` set that prop once a submit has been refused, so both boxes mark themselves; the snackbar is unchanged. Nothing changes for a box that has never been touched and for a submit that succeeds.

Verified locally: refused signup and refused acceptance now show `Bitte bestätige diesen Punkt.` next to each unticked box; ticking both still submits; the checkout consent boxes, the coin-purchase terms box and the terms gate accept/decline flows behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)