### PR TITLE
Wait for the profile before deriving anything from it

### DIFF
--- a/components/user/Profile.vue
+++ b/components/user/Profile.vue
@@ -89,7 +89,6 @@ export default {
 
     const showFreeQuizzesOnly = useAppCookie("showFreeQuizzesOnly");
     return {
-      image,
       username,
       nickname,
       description,

--- a/composables/terms.ts
+++ b/composables/terms.ts
@@ -23,11 +23,15 @@ export const useTermsGateDismissed = () => useState("termsGateDismissed", () => 
  *
  * Nothing is kept on the client: the answer is derived from the user profile
  * that `GET /auth/users/me` returns, so the server row is the only record.
+ * As long as that profile has not arrived - a slow or unreachable API - the
+ * gate stays closed: the `user` cookie carries no `terms_version`, and asking
+ * again would let a user who has long accepted record a refusal by mistake.
  */
 export function needsTermsAcceptance(path: string) {
   const user = <any>useUser();
 
   if (!!!isAuth.value || !!!user.value?.id) return false;
+  if (!!!useProfileLoaded().value) return false;
   if (useTermsGateDismissed().value) return false;
   if (TERMS_GATE_EXEMPT_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
 

--- a/composables/user.ts
+++ b/composables/user.ts
@@ -8,6 +8,16 @@ export const useRefreshToken = () => useState("refreshToken", () => "");
 export const useShowConfetti = () => useState("showConfetti", () => false);
 
 /**
+ * Whether the full profile has been loaded from the API in this app session.
+ *
+ * The `user` cookie only carries the id and the two names, so anything that
+ * depends on another field - the e-mail address, the invoice address, the
+ * accepted version of the terms - has to wait for `GET /auth/users/me` instead
+ * of treating the missing field as "not set".
+ */
+export const useProfileLoaded = () => useState("profileLoaded", () => false);
+
+/**
  * The `user` cookie only carries what the interface needs before the profile
  * has been loaded from the API: the id and the two names. Everything else
  * (e-mail address, invoice address, VAT id, ...) stays on the server and is
@@ -65,6 +75,8 @@ export function restoreStates() {
   const user = <any>useUser();
   const cookie_user = <any>useAppCookie("user");
   user.value = cookie_user.value ?? null;
+  // The cookie is not the profile; the plugin loads that right afterwards.
+  useProfileLoaded().value = false;
 
   const session = <any>useSession();
   const cookie_session = <any>useAppCookie("session");
@@ -81,6 +93,8 @@ export function restoreStates() {
 
 export function setStates(response: any) {
   setUser(response?.user ?? null);
+  // Login, signup and refresh answer with the full profile.
+  useProfileLoaded().value = !!response?.user;
 
   const session = <any>useSession();
   const cookie_session = <any>useAppCookie("session");
@@ -132,6 +146,7 @@ export async function getUser() {
     const response = await GET(`/auth/users/me`);
 
     setUser(response);
+    useProfileLoaded().value = true;
 
     return [response, null];
   } catch (error: any) {

--- a/pages/morphcoins/paypal.vue
+++ b/pages/morphcoins/paypal.vue
@@ -55,11 +55,11 @@
         <div class="flex gap-box">
           <h3 class="text-body-1 text-body">{{ t("Headings.UserType") }}:</h3>
           <p class="text-body-1 text-black">
-            {{ t(user.business ? "Headings.Business" : "Headings.Person") }}
+            {{ t(user?.business ? "Headings.Business" : "Headings.Person") }}
           </p>
         </div>
 
-        <template v-if="user.business">
+        <template v-if="user?.business">
           <div class="flex gap-box">
             <h3 class="text-body-1 m-0 text-body">{{ t("Inputs.FirstName") }}:</h3>
             <p v-if="user && user.first_name" class="text-body-1 m-0 text-black">


### PR DESCRIPTION
Follow-up review of the changes merged today. Since the `user` cookie was
slimmed down to the id and the two names, the rest of the profile only
arrives with `GET /auth/users/me`. Three places still read it as if it were
already there.

### `/profile` did not render at all

`components/user/Profile.vue` still returned an `image` binding after the
computed behind it was removed together with the Gravatar URLs, so the
component threw while rendering. `/profile` and `/auth/login` while logged
in (which redirects there) showed the error page.

### The coin checkout did not render without a profile

`pages/morphcoins/paypal.vue` read `user.business` in the template without a
guard, so the page threw whenever the profile could not be loaded while a
session cookie was present.

### The terms gate asked users who had already accepted

`needsTermsAcceptance()` compared `user.terms_version` with the current
version. The cookie profile has no `terms_version`, so between the app
starting and the profile arriving - and permanently if the API answers
slowly or not at all - every logged in user was asked to accept again.
Pressing "Später entscheiden" then recorded a refusal on the server that
the user never made.

A `profileLoaded` state now records whether the profile in the application
state came from the API. The gate stays closed until it did; the behaviour
with a loaded profile is unchanged.

### Verified

Production build driven headlessly (system chromium) against a stub API:

- `/profile` renders again; before this change it was the error page.
- With `GET /auth/users/me` answering 500, and with it answering after 8s
  (past the 5s startup timeout), the gate no longer appears and the coin
  checkout renders.
- With a normal profile the gate still appears on every non-exempt route,
  both buttons still call `/auth/users/me/terms` and `/terms/decline`,
  and "Später entscheiden" still keeps it closed for the rest of the app
  session.
- `npm run lint` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)