### PR TITLE
Keep the terms gate off the declaration pages and trap the keyboard in it

### DIFF
--- a/components/TermsGate.vue
+++ b/components/TermsGate.vue
@@ -8,7 +8,11 @@
   be dismissed by accident.
 
   It is rendered from `app.vue` into the slot of whichever layout is active, so
-  it reaches every route.
+  it reaches every route, except the ones a user has to be able to reach no
+  matter what they think of the new version (`composables/terms.ts`).
+
+  `aria-modal` promises that everything behind it is unreachable, so the
+  keyboard is kept inside it for as long as it is open.
 
   Nothing is remembered on the client beyond this app session. Whether the gate
   shows is derived from the `terms_version` on the profile that the API returns;
@@ -17,6 +21,7 @@
 <template>
   <section
     v-if="show"
+    ref="refGate"
     class="fixed left-0 top-0 z-[100] flex h-screen w-screen items-center justify-center overflow-y-auto bg-[#0b192edd] p-4"
     role="dialog"
     aria-modal="true"
@@ -88,6 +93,7 @@ export default defineComponent({
     const user = <any>useUser();
     const dismissed = useTermsGateDismissed();
 
+    const refGate = ref<HTMLElement | null>(null);
     const termsAndConditions = ref(false);
     const ageConfirmed = ref(false);
     const submitting = ref(false);
@@ -98,6 +104,8 @@ export default defineComponent({
     const attempted = ref(false);
 
     const show = computed(() => needsTermsAcceptance(route.path));
+
+    useFocusTrap(refGate, show);
     const valid = computed(() => termsAndConditions.value && ageConfirmed.value);
 
     // The link to the terms replaces the `%%%` placeholder in the sentence.
@@ -150,6 +158,7 @@ export default defineComponent({
 
     return {
       t,
+      refGate,
       show,
       bodyParts,
       submitting,

--- a/composables/focusTrap.ts
+++ b/composables/focusTrap.ts
@@ -1,0 +1,107 @@
+import type { Ref } from "vue";
+
+/**
+ * Keeps the keyboard inside a modal for as long as it is on screen.
+ *
+ * A dialog that carries `aria-modal="true"` tells assistive technology that
+ * everything behind it is unreachable. Without this the promise is only half
+ * true: the tab order still walks through the page underneath, so a keyboard
+ * user reaches the navigation and the buttons the dialog is covering.
+ *
+ * The trap moves the focus into the dialog when it opens, cycles `Tab` and
+ * `Shift+Tab` at its two ends, pulls the focus back if it escaped, and returns
+ * it to the element that was focused before when the dialog closes. It only
+ * acts at the ends of the ring, so anything inside that handles `Tab` itself -
+ * a code editor, for example - keeps working; a `Tab` another handler has
+ * already dealt with is left alone.
+ */
+const FOCUSABLE = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function focusable(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+    (element) => element.getClientRects().length > 0
+  );
+}
+
+export function useFocusTrap(container: Ref<HTMLElement | null>, active: Ref<boolean>) {
+  let previous: HTMLElement | null = null;
+  let listening = false;
+  let moved = false;
+
+  function onkeydown(event: KeyboardEvent) {
+    if (event.key !== "Tab" || event.defaultPrevented) return;
+
+    const element = container.value;
+    if (!!!element) return;
+
+    const elements = focusable(element);
+    if (!elements.length) {
+      event.preventDefault();
+      return;
+    }
+
+    const first = elements[0];
+    const last = elements[elements.length - 1];
+    const current = document.activeElement as HTMLElement | null;
+
+    if (!!!current || !element.contains(current)) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+      return;
+    }
+
+    if (event.shiftKey && current === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && current === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function release() {
+    if (!!!listening) return;
+    listening = false;
+    moved = false;
+    document.removeEventListener("keydown", onkeydown);
+    previous?.focus?.();
+    previous = null;
+  }
+
+  // The element is watched along with the flag: the dialog is often already
+  // open when the component first renders, so the element appears only after
+  // the layout around it has been resolved.
+  watch(
+    [active, container] as const,
+    ([open, element]) => {
+      if (!!!open) return release();
+
+      if (!!!listening) {
+        listening = true;
+        previous = (document.activeElement as HTMLElement | null) ?? null;
+        document.addEventListener("keydown", onkeydown);
+      }
+
+      if (!!!element || moved) return;
+      moved = true;
+
+      const [target] = focusable(element);
+      if (target) {
+        target.focus();
+      } else {
+        element.setAttribute("tabindex", "-1");
+        element.focus();
+      }
+    },
+    { immediate: true, flush: "post" }
+  );
+
+  onUnmounted(() => document.removeEventListener("keydown", onkeydown));
+}

--- a/composables/terms.ts
+++ b/composables/terms.ts
@@ -3,10 +3,18 @@ export const TERMS_VERSION = "2026-09";
 
 /**
  * Routes on which the re-acceptance gate stays hidden: the documents the gate
- * links to, and the account page the user needs in order to delete the account
- * instead of accepting.
+ * links to, the account page the user needs in order to delete the account
+ * instead of accepting, and the two declaration pages. § 312k Abs. 2 BGB and
+ * § 356a BGB want the cancellation and the withdrawal to be reachable
+ * directly, so nothing may be put in front of them - least of all a dialog
+ * about the very terms the user is about to leave behind.
  */
-const TERMS_GATE_EXEMPT_PREFIXES = ["/docs", "/account"];
+const TERMS_GATE_EXEMPT_PREFIXES = [
+  "/docs",
+  "/account",
+  "/vertrag-kuendigen",
+  "/vertrag-widerrufen",
+];
 
 /**
  * Whether the gate has been dismissed with "decide later" since the app was


### PR DESCRIPTION
Follow-up review of the changes merged today.

### The gate covered the cancellation and withdrawal pages

`/vertrag-kuendigen` and `/vertrag-widerrufen` were not in the exempt list,
so a logged in user with an outdated `terms_version` who pressed
"Verträge hier kündigen" first had to deal with a dialog about the very
terms they are about to leave behind. § 312k Abs. 2 BGB and § 356a BGB want
those pages reachable directly; they now join the documents and the account
page.

### The gate did not keep the keyboard inside itself

The dialog carries `aria-modal="true"`, which tells assistive technology
that everything behind it is unreachable. It was not: nothing was focused
when the dialog opened, and tabbing walked through the navigation, the
dashboard and the contract bar underneath before reaching the dialog at
all.

`composables/focusTrap.ts` moves the focus into the dialog when it opens,
cycles `Tab` and `Shift+Tab` at its two ends, pulls the focus back if it
escapes, and returns it to where it was when the dialog closes. It only
acts at the ends of the ring and ignores a `Tab` another handler has
already handled, so anything inside a dialog that does its own `Tab`
handling keeps working.

### Verified

Production build driven headlessly (system chromium) against a stub API:

- Gate absent on `/vertrag-kuendigen` and `/vertrag-widerrufen`, still
  present on `/dashboard`, `/subscription` and `/morphcoins/buy`, still
  absent on `/docs/*`, `/account` and the error page.
- Focus lands inside the dialog when it opens; twelve consecutive `Tab`
  presses stay inside it and cycle. Before the change the first eleven
  were all outside.
- Accepting still posts `/auth/users/me/terms` and closes the dialog,
  accepting without both boxes still refuses, postponing still posts
  `/auth/users/me/terms/decline` and keeps it closed for the rest of the
  app session and shows it again after a reload.
- `npm run lint` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)