### PR TITLE
feat(account): let users download a copy of their data

### DIFF
--- a/components/account/DownloadData.vue
+++ b/components/account/DownloadData.vue
@@ -1,0 +1,77 @@
+<template>
+  <article class="card flex flex-col items-center justify-center bg-secondary style-card">
+    <ArrowDownTrayIcon class="mb-4 h-10 w-10 max-w-xl text-accent" />
+
+    <h2 class="text-heading-2">{{ t("Headings.DownloadMyData") }}</h2>
+
+    <div class="mb-8 mt-2 flex items-center space-x-4">
+      <DocumentTextIcon class="h-8 w-8 max-w-xl text-accent" />
+      <p class="text-center">
+        {{ t("Body.DownloadMyData") }}
+      </p>
+    </div>
+
+    <InputBtn :loading="loading" @click="onclick">
+      {{ t("Buttons.DownloadMyData") }}
+    </InputBtn>
+  </article>
+</template>
+
+<script lang="ts">
+import { DocumentTextIcon } from "@heroicons/vue/24/outline";
+import { ArrowDownTrayIcon } from "@heroicons/vue/24/solid";
+import { defineComponent } from "vue";
+import { useI18n } from "vue-i18n";
+
+export default defineComponent({
+  components: {
+    ArrowDownTrayIcon,
+    DocumentTextIcon,
+  },
+  setup() {
+    const { t } = useI18n();
+
+    const loading = ref(false);
+
+    /** Offer the export as a file instead of opening it in the browser. */
+    function saveAsFile(data: any) {
+      const date = new Date().toISOString().slice(0, 10);
+      const url = URL.createObjectURL(
+        new Blob([JSON.stringify(data, null, 2)], { type: "application/json" })
+      );
+
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `bootstrap-academy-${date}.json`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+
+      URL.revokeObjectURL(url);
+    }
+
+    async function onclick() {
+      loading.value = true;
+      const [data, error] = await exportUserData();
+      loading.value = false;
+
+      if (!!!data) {
+        openSnackbar("error", error?.detail ?? "Error.DownloadMyDataFailed");
+        return;
+      }
+
+      saveAsFile(data);
+
+      // The file is saved either way, but the user has to know when a part of
+      // it is missing because one of the services could not be read.
+      if (data.complete === false) {
+        openSnackbar("warning", "Error.DownloadMyDataIncomplete");
+      } else {
+        openSnackbar("success", "Success.DownloadMyData");
+      }
+    }
+
+    return { t, loading, onclick };
+  },
+});
+</script>

--- a/composables/user.ts
+++ b/composables/user.ts
@@ -173,6 +173,35 @@ export async function editUser(body: any) {
   }
 }
 
+/**
+ * Download everything the platform has stored about the authenticated user
+ * (Art. 15 and 20 GDPR). The endpoint is rate limited, so a second call within
+ * a few minutes answers with 429; that case gets its own translated message
+ * because the backend detail is not translatable.
+ */
+export async function exportUserData() {
+  const user = <any>useUser();
+  let user_id = user?.value?.id ?? null;
+
+  try {
+    if (!!!user_id) {
+      throw { data: { detail: "Error.DownloadMyDataFailed" } };
+    }
+
+    const response = await GET(`/auth/users/${user_id}/export`);
+
+    return [response, null];
+  } catch (error: any) {
+    const status = error?.status ?? error?.statusCode ?? null;
+
+    if (status == 429) {
+      return [null, { detail: "Error.DownloadMyDataRateLimit" }];
+    }
+
+    return [null, error?.data ?? { detail: "Error.DownloadMyDataFailed" }];
+  }
+}
+
 export async function deleteUser() {
   const user = <any>useUser();
   let user_id = user?.value?.id ?? null;

--- a/locales/de.json
+++ b/locales/de.json
@@ -288,6 +288,7 @@
     "CertificatesBased": "Basierend auf Zertifikaten",
     "WhoWeAre": "Wer wir sind",
     "DeleteAccount": "Konto löschen",
+    "DownloadMyData": "Meine Daten herunterladen",
     "NewTermsAndConditions": "Neue AGB",
     "ResetPassword": "Passwort zurücksetzen",
     "Euros": "Euro",
@@ -492,6 +493,7 @@
     "NotEnoughMorphcoins": "Du hast nicht genügend MorphCoins",
     "GetCodeViaEmail": "Erhalte einen Code per E-Mail",
     "IrreversibleAction": "nicht rückgängig machbar",
+    "DownloadMyData": "Du erhältst alle zu deinem Konto gespeicherten Daten als JSON-Datei: Konto- und Profildaten, Sitzungen, verknüpfte Konten, Morphcoins und Rechnungen sowie deinen Lernfortschritt, deine Einsendungen und deine Buchungen.",
     "NewTermsAndConditions": "Wir haben unsere AGB geändert: Bis du der neuen Fassung zustimmst, gilt für deinen bestehenden Vertrag die bisherige Fassung der %%% weiter, und wir können den Nutzungsvertrag deshalb mit der dort geregelten Frist von vier Wochen ordentlich kündigen.",
     "LooseProgressMorphCoinsAndCourses": "Du verlierst allen Fortschritt,%%%gekaufte MorphCoins und Kurse",
     "NotRecommended": "nicht empfohlen",
@@ -865,6 +867,7 @@
     "ViewCertificate": "Zertifikat ansehen",
     "Logout": "Ausloggen",
     "DeleteAccount": "Ja, Konto löschen",
+    "DownloadMyData": "Meine Daten herunterladen",
     "AcceptTermsAndConditions": "AGB akzeptieren",
     "DecideLater": "Später entscheiden",
     "Cancel": "Abbrechen",
@@ -1022,6 +1025,7 @@
     "ResendAccountVerificationCode": "Der Kontobestätigungscode wurde dir per E-Mail zugeschickt.",
     "EditProfile": "Profil erfolgreich bearbeitet.",
     "DeleteAccount": "Dein Konto wurde erfolgreich gelöscht.",
+    "DownloadMyData": "Deine Daten wurden heruntergeladen.",
     "DisabledMFA": "Deine MFA wurde erfolgreich deaktiviert.",
     "InitializeMFA": "Deine Multi-Faktor-Authentifizierung (MFA) wurde erfolgreich eingerichtet. Um MFA zu aktivieren, gib bitte diesen TOTP-Schlüssel in deine TOTP-App ein, z. B. Google Authenticator oder Authy. Darin wird ein kurzlebiger Authentifizierungscode generiert, mit dem du MFA aktivieren kannst.",
     "EnableMFACode": "Dein MFA-Code wurde erfolgreich aktiviert. Von nun an, gib zur Anmeldung Ihren 6-stelligen MFA-Code zusammen mit deinem Passwort und Ihrer E-Mail-Adresse ein.",
@@ -1150,7 +1154,10 @@
     "InvalidCoinAmount": "Ungültige Anzahl an Morphcoins. Bitte starte den Kauf erneut.",
     "TooManyRequests": "Zu viele Anfragen. Bitte versuchen Sie es später erneut oder schreiben Sie uns an hallo{'@'}bootstrap.academy.",
     "DeclarationNotSubmitted": "Ihre Erklärung konnte nicht übermittelt werden. Bitte versuchen Sie es erneut oder senden Sie Ihre Erklärung an hallo{'@'}bootstrap.academy.",
-    "WithdrawalConsentMissing": "Bitte gib die beiden Erklärungen zum Widerrufsrecht ab, um zu bestellen"
+    "WithdrawalConsentMissing": "Bitte gib die beiden Erklärungen zum Widerrufsrecht ab, um zu bestellen",
+    "DownloadMyDataRateLimit": "Du hast deine Daten gerade erst heruntergeladen. Bitte versuche es in einigen Minuten erneut.",
+    "DownloadMyDataIncomplete": "Die Datei wurde gespeichert, aber ein Teil deiner Daten konnte gerade nicht abgerufen werden. Welcher Teil fehlt, steht in der Datei unter „services“. Bitte versuche es später noch einmal.",
+    "DownloadMyDataFailed": "Deine Daten konnten nicht heruntergeladen werden. Bitte versuche es später erneut."
   },
   "Months": {
     "January": "Januar",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -288,6 +288,7 @@
     "CertificatesBased": "Certificates Based",
     "WhoWeAre": "Who we are",
     "DeleteAccount": "Delete Account",
+    "DownloadMyData": "Download my data",
     "NewTermsAndConditions": "Updated terms",
     "ResetPassword": "Reset Password",
     "Euros": "Euros",
@@ -493,6 +494,7 @@
     "NotEnoughMorphcoins": "You don't have enough MorphCoins",
     "GetCodeViaEmail": "Receive a code by email",
     "IrreversibleAction": "cannot be reversed",
+    "DownloadMyData": "You receive all data stored for your account as a JSON file: account and profile data, sessions, linked accounts, Morphcoins and invoices as well as your learning progress, your submissions and your bookings.",
     "NewTermsAndConditions": "We have changed our terms and conditions: until you accept the new version, the previous version of the %%% keeps applying to your existing contract, and we may therefore terminate the contract with the four-week notice period set out there.",
     "LooseProgressMorphCoinsAndCourses": "You lose all progress,%%%purchased MorphCoins and courses",
     "NotRecommended": "not recommended",
@@ -871,6 +873,7 @@
     "ViewCertificate": "View Certificate",
     "Logout": "Logout",
     "DeleteAccount": "Yes, Delete Account",
+    "DownloadMyData": "Download my data",
     "AcceptTermsAndConditions": "Accept terms",
     "DecideLater": "Decide later",
     "Cancel": "Cancel",
@@ -1025,6 +1028,7 @@
     "ResendAccountVerificationCode": "Account verification code has been emailed to you.",
     "EditProfile": "Profile Edited successfully.",
     "DeleteAccount": "Your account has been deleted successfully.",
+    "DownloadMyData": "Your data has been downloaded.",
     "DisabledMFA": "Your MFA has been successfully disabled.",
     "InitializeMFA": "Your multi-factor authentication (MFA) has been successfully initiated. To enable your MFA, please enter this TOTP key to your TOTP app e.g Google Authenticator, Authy, etc. You will get short-lived authentication code which you will use to enable your MFA.",
     "EnableMFACode": "Your MFA code has been successfully enabled. From now on in order to login, you will enter your 6-digit MFA code along with your password and email.",
@@ -1152,7 +1156,10 @@
     "InvalidCoinAmount": "Invalid number of Morphcoins. Please start the purchase again.",
     "TooManyRequests": "Too many requests. Please try again later or write to us at hallo{'@'}bootstrap.academy.",
     "DeclarationNotSubmitted": "Your declaration could not be submitted. Please try again or send your declaration to hallo{'@'}bootstrap.academy.",
-    "WithdrawalConsentMissing": "Please give both withdrawal declarations to place the order"
+    "WithdrawalConsentMissing": "Please give both withdrawal declarations to place the order",
+    "DownloadMyDataRateLimit": "You have just downloaded your data. Please try again in a few minutes.",
+    "DownloadMyDataIncomplete": "The file has been saved, but a part of your data could not be collected right now. The file lists the missing part under “services”. Please try again later.",
+    "DownloadMyDataFailed": "Your data could not be downloaded. Please try again later."
   },
   "Months": {
     "January": "January",

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -28,6 +28,7 @@
       <AccountChangePassword class="md:w-1/2" />
     </div>
     <div class="mb-16 justify-between max-md:space-y-6 md:flex md:space-x-12">
+      <AccountDownloadData class="md:w-1/2" />
       <AccountDelete class="md:w-1/2" />
     </div>
   </main>


### PR DESCRIPTION
The account page gets a "Meine Daten herunterladen" card next to the deletion card. It calls the new `GET /auth/users/{user_id}/export` endpoint (backend #734) and saves the answer as `bootstrap-academy-<date>.json`, so that a user can get everything the platform stores about them without writing to support.

## What is in the file

The account and profile data, the sessions, the linked OAuth2 accounts, the Morphcoin balance and transactions, the hearts, the premium membership, the invoices, the contract declarations and the withdrawal declarations, plus the learning progress, the submissions and the event bookings collected from skills-ms, challenges-ms and events-ms.

## Snackbar cases

All three are translated in both locales:

- saved and complete → success,
- saved but a service could not be read (`complete: false`) → warning that names where the gap is documented in the file,
- failed → error, with a dedicated message for the rate limit of the endpoint, because the `detail` of the API answer is English prose and not a translation key.

## Verified locally

`npm run format:check` and `npm run lint` are clean. The flow was exercised against a local backend: the button downloads the JSON file, a second click within the window shows the rate-limit message, and with the microservices unreachable the file is still saved and the warning appears.

Files: `components/account/DownloadData.vue` (new), `composables/user.ts`, `pages/account/index.vue`, `locales/de.json`, `locales/en-US.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)