### PR TITLE
Let users hide themselves from the leaderboards

### DIFF
--- a/components/form/Profile.vue
+++ b/components/form/Profile.vue
@@ -54,6 +54,20 @@
 
     <article class="mt-card">
       <h2 class="text-heading-2 font-black mb-box">
+        {{ t("Headings.Visibility") }}
+      </h2>
+      <InputCheckbox
+        id="ProfileShowOnLeaderboard"
+        label="Inputs.ShowOnLeaderboard"
+        v-model="showOnLeaderboard"
+      />
+      <p class="text-body-2 text-body mt-box">
+        {{ t("Body.ShowOnLeaderboard") }}
+      </p>
+    </article>
+
+    <article class="mt-card">
+      <h2 class="text-heading-2 font-black mb-box">
         {{ t("Headings.UserType") }}
       </h2>
       <button
@@ -130,6 +144,9 @@ export default defineComponent({
     const { t } = useI18n();
 
     const business = ref(false);
+    // The API stores the opt-out; the form asks the other way round, so that
+    // the box is ticked by default and unticking it hides the user.
+    const showOnLeaderboard = ref(true);
 
     // ============================================================= refs
     const refForm = ref<HTMLFormElement | null>(null);
@@ -271,6 +288,7 @@ export default defineComponent({
       form.first_name.value = data?.first_name ?? "";
       form.last_name.value = data?.last_name ?? "";
       business.value = data?.business ?? false;
+      showOnLeaderboard.value = !(data?.leaderboard_opt_out ?? false);
     }
 
     watch(
@@ -291,6 +309,7 @@ export default defineComponent({
         const [success, error] = await editUser({
           ...form.body(),
           business: business.value,
+          leaderboard_opt_out: !showOnLeaderboard.value,
         });
         form.submitting = false;
 
@@ -352,6 +371,7 @@ export default defineComponent({
       t,
       hintNickname,
       business,
+      showOnLeaderboard,
     };
   },
 });

--- a/components/leaderboard/Listing.vue
+++ b/components/leaderboard/Listing.vue
@@ -21,14 +21,13 @@
 
     <div class="mt-6 flex justify-center">
       <InputBtn
-        v-if="leaderBoardList.length < totalLeaderboardUsers"
+        v-if="hasMore"
         :loading="btnLoading"
         @click="loadMore()"
         :icon="TrophyIcon"
         iconRight
         :class="{
-          'pointer-events-none opacity-70':
-            btnLoading || leaderBoardList.length >= totalLeaderboardUsers,
+          'pointer-events-none opacity-70': btnLoading,
         }"
       >
         <div>
@@ -36,10 +35,7 @@
         </div>
       </InputBtn>
     </div>
-    <p
-      v-if="leaderBoardList.length == totalLeaderboardUsers"
-      class="flex flex-col items-center text-accent"
-    >
+    <p v-if="!hasMore" class="flex flex-col items-center text-accent">
       <component v-if="TrophyIcon" :is="TrophyIcon" class="mb-4 h-10 w-10 bg-primary" />
       {{ t("Headings.NoMoreUser") }}
     </p>
@@ -62,6 +58,10 @@ export default {
     const btnLoading = ref(false);
     const route: any = useRoute();
     const totalLeaderboardUsers = useTotalLeaderboardUsers();
+    // `totalLeaderboardUsers` counts every position on the leaderboard, while
+    // the response omits users who asked not to be listed, so the loaded list
+    // can stay shorter than the total. Page by offset instead of by length.
+    const hasMore = computed(() => offset.value + limit.value < totalLeaderboardUsers.value);
     const topThreeUsers = computed(() => props.leaderBoardList.slice(0, 3));
     const remainingUsers = computed(() =>
       props.leaderBoardList.slice(3).filter((user: any) => user?.rank > 3)
@@ -99,6 +99,7 @@ export default {
       btnLoading,
       offset,
       totalLeaderboardUsers,
+      hasMore,
       topThreeUsers,
       remainingUsers,
     };

--- a/locales/de.json
+++ b/locales/de.json
@@ -374,7 +374,8 @@
     "DeclarationReference": "Vorgangsnummer",
     "CancellationReason": "Grund der Kündigung",
     "OrderDetails": "Angaben zur Bestellung",
-    "ContractTermination": "Vertragsbeendigung"
+    "ContractTermination": "Vertragsbeendigung",
+    "Visibility": "Sichtbarkeit"
   },
   "Body": {
     "CalendarSubscription": "Mit diesem Link abonnierst du deine Termine in einer Kalender-App. Wer den Link kennt, kann deine Termine lesen – teile ihn also nicht. Erneuerst du ihn, verlieren alle bisher eingerichteten Abos den Zugriff.",
@@ -526,7 +527,9 @@
     "WithdrawalConsentServicePerformance": "Ich verlange ausdrücklich und stimme zu, dass Sie vor Ablauf der Widerrufsfrist mit der Erbringung der Dienstleistung beginnen.",
     "WithdrawalConsentServiceLoss": "Mir ist bekannt, dass mein Widerrufsrecht mit vollständiger Erbringung der Dienstleistung erlischt.",
     "WithdrawalConsentDigitalPerformance": "Ich stimme ausdrücklich zu, dass Sie vor Ablauf der Widerrufsfrist mit der Ausführung des Vertrags beginnen.",
-    "WithdrawalConsentDigitalLoss": "Mir ist bekannt, dass mein Widerrufsrecht mit Beginn der Ausführung des Vertrags erlischt."
+    "WithdrawalConsentDigitalLoss": "Mir ist bekannt, dass mein Widerrufsrecht mit Beginn der Ausführung des Vertrags erlischt.",
+    "ShowOnLeaderboard": "Ist der Haken gesetzt, erscheinst du mit Anzeigename, Punktestand und Rang in den Bestenlisten, die alle angemeldeten Nutzer:innen sehen können. Entfernst du ihn, wirst du dort nicht mehr aufgeführt. Deine Punkte werden weiterhin gezählt und deinen eigenen Rang siehst du weiterhin.",
+    "LeaderboardOptOut": "Nicht alle Nutzer:innen werden hier aufgeführt: Wer möchte, kann sich in den Profileinstellungen aus den Bestenlisten ausblenden."
   },
   "AltAttributes": {
     "BootstrapAcademyLogo": "Bootstrap Academy Logo",
@@ -753,7 +756,8 @@
     "EndAtNextPossibleDate": "Zum nächstmöglichen Zeitpunkt",
     "EndAtDate": "Zum folgenden Datum",
     "EndDate": "Beendigungsdatum",
-    "OrderDetails": "Bestellnummer oder sonstige Angaben zur Bestellung (optional)"
+    "OrderDetails": "Bestellnummer oder sonstige Angaben zur Bestellung (optional)",
+    "ShowOnLeaderboard": "In den Bestenlisten anzeigen"
   },
   "Buttons": {
     "Matching": "Matching",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -374,7 +374,8 @@
     "DeclarationReference": "Reference number",
     "CancellationReason": "Reason for the cancellation",
     "OrderDetails": "Order details",
-    "ContractTermination": "Ending a contract"
+    "ContractTermination": "Ending a contract",
+    "Visibility": "Visibility"
   },
   "Body": {
     "CalendarSubscription": "Subscribe to your events in a calendar app with this link. Anyone who knows the link can read your events, so do not share it. Creating a new one cuts off every subscription that uses the old link.",
@@ -527,7 +528,9 @@
     "WithdrawalConsentServicePerformance": "Ich verlange ausdrücklich und stimme zu, dass Sie vor Ablauf der Widerrufsfrist mit der Erbringung der Dienstleistung beginnen.",
     "WithdrawalConsentServiceLoss": "Mir ist bekannt, dass mein Widerrufsrecht mit vollständiger Erbringung der Dienstleistung erlischt.",
     "WithdrawalConsentDigitalPerformance": "Ich stimme ausdrücklich zu, dass Sie vor Ablauf der Widerrufsfrist mit der Ausführung des Vertrags beginnen.",
-    "WithdrawalConsentDigitalLoss": "Mir ist bekannt, dass mein Widerrufsrecht mit Beginn der Ausführung des Vertrags erlischt."
+    "WithdrawalConsentDigitalLoss": "Mir ist bekannt, dass mein Widerrufsrecht mit Beginn der Ausführung des Vertrags erlischt.",
+    "ShowOnLeaderboard": "While this is ticked, your display name, score and rank appear on the leaderboards that every logged-in user can see. Untick it and you are no longer listed there. Your score still counts and you can still see your own rank.",
+    "LeaderboardOptOut": "Not everyone is listed here: anyone can hide themselves from the leaderboards in their profile settings."
   },
   "AltAttributes": {
     "BootstrapAcademyLogo": "Bootstrap Academy logo",
@@ -754,7 +757,8 @@
     "EndAtNextPossibleDate": "At the earliest possible date",
     "EndAtDate": "On the following date",
     "EndDate": "End date",
-    "OrderDetails": "Order number or other details of the order (optional)"
+    "OrderDetails": "Order number or other details of the order (optional)",
+    "ShowOnLeaderboard": "Show me on the leaderboards"
   },
   "Buttons": {
     "Matching": "Matching",

--- a/pages/challenges/leader-board.vue
+++ b/pages/challenges/leader-board.vue
@@ -29,6 +29,13 @@
       </div>
 
       <InputButtonToggle :buttonOptions="buttonOptions" v-model="selectedbutton" />
+
+      <p class="text-body-2 max-w-2xl text-center text-body mt-box">
+        {{ t("Body.LeaderboardOptOut") }}
+        <NuxtLink to="/profile/edit" class="text-accent hover:underline">
+          {{ t("Headings.EditProfile") }}
+        </NuxtLink>
+      </p>
     </div>
 
     <SkeletonLeaderboard v-if="loading && selectedbutton != 1" />

--- a/types/userTypes.ts
+++ b/types/userTypes.ts
@@ -14,6 +14,7 @@ export class User {
   last_login: number = 0;
   last_name: string = "";
   last_name_change: number = 0;
+  leaderboard_opt_out: boolean = false;
   mfa_enabled: boolean = false;
   name: string = "";
   password: boolean = false;


### PR DESCRIPTION
The user profile stores whether a user asked not to be listed on the
leaderboards; this exposes the setting in the UI.

- `types/userTypes.ts` picks up `leaderboard_opt_out`.
- The profile form gets a "Visibility" section with a checkbox
  ("In den Bestenlisten anzeigen" / "Show me on the leaderboards"). It is
  asked the other way round from the stored flag, so the box is ticked by
  default and unticking it hides the user. It is saved with the rest of
  the profile through the existing `PATCH`, which also refreshes the user
  state the form reads from.
- The leaderboard page notes that not everyone is listed and links to the
  profile settings.
- The "load more" button pages by `offset` instead of by the length of the
  loaded list: `total` counts every position on the leaderboard while the
  response omits the users who are not listed, so the list can stay
  shorter than the total and the old comparison never ended the paging.

Verified locally with `npm run lint`, `npx prettier --check` on the
touched files and `npm run generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)