### PR TITLE
fix(calendar): state the cancellation terms the way they apply

### DIFF
--- a/components/calendar/EventBooking.vue
+++ b/components/calendar/EventBooking.vue
@@ -93,7 +93,10 @@
       >
         <Accordion :title="dialog.heading" class="w-full">
           <Dialog :dialog="dialog">
-            <template #content> </template>
+            <template #content>
+              <h4 class="text-heading-4 mt-box mb-box">{{ t("Headings.CancellationPolicy") }}</h4>
+              <List :items="cancellationPolicy" id="eventCancellationPolicy" />
+            </template>
           </Dialog>
         </Accordion>
       </CalendarEventSummary>
@@ -219,10 +222,6 @@ const cancellationPolicy = reactive([
   "List.EventCancellationPolicy.3",
 ]);
 
-const todayDate = ref("");
-const startDate = ref("");
-const numberOfDaysUntil = ref(0);
-
 function onclickCancel() {
   confirmCancellation.value = true;
   let btnText = "";
@@ -242,7 +241,7 @@ function onclickCancel() {
       break;
   }
 
-  let refund = getCancellationRefundStatus();
+  const refund = getCancellationRefundStatus();
   let body = t("Body.CancelEvent");
 
   if (refund == 100) {
@@ -250,30 +249,35 @@ function onclickCancel() {
   } else if (refund == 50) {
     body = `${body} ${t("Body.CancelEvent50%")}`;
   } else {
-    body = `${body} ${t("Body.CancelEvent0%")}`;
+    // less than 24 hours before the event there is nothing to confirm anymore
+    body = t("Body.CancelEvent0%");
   }
 
   Object.assign(dialog, {
     type: type,
     heading: headingText,
     body: body,
-    primaryBtn: {
-      label: btnText,
-      onclick: async () => {
-        setLoading(true);
-        const [success, error] = await cancelCalendarEvent(props.id);
-        setLoading(false);
+    // the events service refuses a cancellation within the last 24 hours, so it is not offered here
+    primaryBtn:
+      refund == 0
+        ? {}
+        : {
+            label: btnText,
+            onclick: async () => {
+              setLoading(true);
+              const [success, error] = await cancelCalendarEvent(props.id);
+              setLoading(false);
 
-        openSnackbar(
-          success ? "success" : "error",
-          success ? "Success.EventCancelled" : (error?.detail ?? "")
-        );
+              openSnackbar(
+                success ? "success" : "error",
+                success ? "Success.EventCancelled" : (error?.detail ?? "")
+              );
 
-        if (success) {
-          confirmCancellation.value = false;
-        }
-      },
-    },
+              if (success) {
+                confirmCancellation.value = false;
+              }
+            },
+          },
     secondaryBtn: {
       label: "Buttons.Back",
       onclick: () => {
@@ -283,17 +287,15 @@ function onclickCancel() {
   });
 }
 
+// The tiers of the cancellation policy, mirroring the thresholds the events service applies.
+// `start.date - today.date` used to subtract the days of the month from each other, which is off by
+// a month's length whenever the event is in the next month.
 function getCancellationRefundStatus() {
-  let start = convertTimestampToDate(props.start);
-  let today = convertTimestampToDate(new Date().getTime() / 1000);
+  const hoursUntilStart = (props.start * 1000 - Date.now()) / (60 * 60 * 1000);
 
-  numberOfDaysUntil.value = start.date - today.date;
-  todayDate.value = `${today.date} ${t(today.month.string)}, ${today.year}`;
-  startDate.value = `${start.date} ${t(start.month.string)}, ${start.year}`;
-
-  if (numberOfDaysUntil.value > 7) {
+  if (hoursUntilStart >= 7 * 24) {
     return 100;
-  } else if (numberOfDaysUntil.value > 1 && numberOfDaysUntil.value <= 7) {
+  } else if (hoursUntilStart >= 24) {
     return 50;
   } else {
     return 0;

--- a/locales/de.json
+++ b/locales/de.json
@@ -425,7 +425,7 @@
     "CancelEvent": "Bist du sicher, dass du abbrechen möchtest?",
     "CancelEvent100%": "Du hast Anspruch auf 100% Rückerstattung.",
     "CancelEvent50%": "Du hast Anspruch auf 50% Rückerstattung.",
-    "CancelEvent0%": "Du erhältst keine Rückerstattung.",
+    "CancelEvent0%": "Weniger als 24 Stunden vor Beginn ist eine Stornierung hier nicht mehr möglich. Schreib uns an hallo@bootstrap.academy, wenn du nicht teilnehmen kannst.",
     "BookedEventsFilterToolTip": "Zeigt Veranstaltungen an, die von dir gebucht wurden",
     "MyEventsFilterToolTip": "Zeigt Ereignisse an, die von dir erstellt wurden",
     "ThisIsFirstLecture": "Dies ist die erste Vorlesung",
@@ -560,9 +560,9 @@
       "2": "Wenn ein oder mehrere Benutzer dieses Webinar gebucht haben, dann kannst du nur in Notfällen oder im Krankheitsfall stornieren. Andernfalls muss das nächste Webinar kostenlos sein."
     },
     "EventCancellationPolicy": {
-      "1": "7 Tage vor der Veranstaltung oder früher: 100 % Rückerstattung",
-      "2": "1 - 7 Tage vor der Veranstaltung: 50 % Rückerstattung",
-      "3": "weniger als 24 Stunden: 0% Rückerstattung"
+      "1": "Bis 7 Tage vor Beginn: Die Stornierung ist kostenlos, wir erstatten den vollen Preis.",
+      "2": "Später, aber mindestens 24 Stunden vor Beginn: Wir erstatten 50 % des Preises.",
+      "3": "Weniger als 24 Stunden vor Beginn: Eine Stornierung im Kalender ist nicht mehr möglich; der Preis wird einbehalten."
     },
     "Contact": {
       "1": {

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -426,7 +426,7 @@
     "CancelEvent": "Are you sure you want to cancel?",
     "CancelEvent100%": "Your are eligible for 100% refund.",
     "CancelEvent50%": "Your are eligible for 50% refund.",
-    "CancelEvent0%": "You will not get any refund.",
+    "CancelEvent0%": "Less than 24 hours before it starts, the event can no longer be cancelled here. Write to hallo@bootstrap.academy if you cannot attend.",
     "BookedEventsFilterToolTip": "Shows events that are booked by you",
     "MyEventsFilterToolTip": "Shows events that are created by you",
     "ThisIsFirstLecture": "This is the first lecture",
@@ -561,9 +561,9 @@
       "2": "If one or more user(s) have booked this webinar, then you can cancel only in case of emergencies or in case of illness. Otherwise the next webinar has to be free."
     },
     "EventCancellationPolicy": {
-      "1": "7 days before event or earlier: 100% refund",
-      "2": "1 - 7 days before the event: 50% refund",
-      "3": "less than 24 hours: 0% refund"
+      "1": "Up to 7 days before the event: Cancelling is free, we refund the full price.",
+      "2": "Later, but at least 24 hours before the event: We refund 50% of the price.",
+      "3": "Less than 24 hours before the event: Cancelling in the calendar is no longer possible; the price is kept."
     },
     "Contact": {
       "1": {


### PR DESCRIPTION
The cancellation policy for a booked webinar or coaching promised `weniger als 24 Stunden: 0% Rückerstattung`, and the confirmation dialog said `Du erhältst keine Rückerstattung`. Both read as if the booking could still be cancelled inside the last 24 hours, only without getting anything back. The events service answers `403` for exactly that case, and the terms of service (Ziffer 10.3) say a cancellation on the platform is possible up to 24 hours before the event; later only by mail, with the price kept.

* The three tiers now say what applies: the full price back up to seven days before the event, 50 % up to 24 hours before it, and no cancellation in the calendar after that, with the support address for anybody who cannot attend. English twin updated as well.
* Inside the last 24 hours the dialog no longer offers a "Ja, stornieren" button, because the request would only fail.
* `getCancellationRefundStatus` decided which of the three sentences to show by subtracting the days of the month from each other (`start.date - today.date`). That is off by the length of a month as soon as the event falls into the next one: an event eight days away, seen on the 28th, came out as -20 days and was presented as non-refundable. It now compares the timestamps and uses the same thresholds as the events service (`>= 7 * 24 h`, `>= 24 h`). The three refs that only held intermediate values of that calculation are removed; nothing rendered them.
* The list of tiers was assembled in the component but never rendered anywhere, so it is now shown in the confirmation dialog, next to the question it belongs to.

The service side of this is Bootstrap-Academy/events-ms#218.

### Verification
`npm run lint`, `npm run format:check` and `npm run generate` are clean. In the app, opening a booked event more than seven days out offers the cancellation with the full refund, one two days out with 50 %, and one twelve hours out shows the policy with no cancel button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
