### PR TITLE
docs(legal): time the moderation notice to the human decision and name all audited admin reads

### DIFF
--- a/pages/docs/privacy.vue
+++ b/pages/docs/privacy.vue
@@ -865,9 +865,10 @@
       </p>
       <p>
         Jede verändernde Anfrage einer Administrator:in (Anlegen, Ändern, Löschen, Anmelden in einem
-        anderen Konto) sowie der Abruf eines Datenexports und der Abruf der Liste der
-        Rechnungsdokumente (Abschnitt 15.4) werden in einem Verwaltungsprotokoll festgehalten – auch
-        dann, wenn die Anfrage abgelehnt wurde. Ein Eintrag enthält Zeitpunkt, Kennung der
+        anderen Konto) sowie der Abruf eines Datenexports, der Abruf der Nutzerliste, der Abruf der
+        Liste der Rechnungsdokumente (Abschnitt 15.4) und der Abruf der Liste der Kündigungs- und
+        Widerrufserklärungen (Abschnitt 15.6) werden in einem Verwaltungsprotokoll festgehalten –
+        auch dann, wenn die Anfrage abgelehnt wurde. Ein Eintrag enthält Zeitpunkt, Kennung der
         handelnden Administrator:in, HTTP-Methode und Pfad der Anfrage (ohne Abfrageparameter;
         Kennungen im Pfad bleiben enthalten), Kennung des betroffenen Kontos, Antwortstatus und
         Anfragekennung; Inhalte der Anfrage werden nicht gespeichert. Zugriffe von Betreiber:innen

--- a/pages/docs/terms-and-conditions.vue
+++ b/pages/docs/terms-and-conditions.vue
@@ -729,15 +729,17 @@
         nach Ziffer 14.7 überprüfen zu lassen.
       </p>
       <p>
-        14.6 Begründung unserer Entscheidungen: Entfernen oder blenden wir einen Nutzerinhalt aus,
-        sperren wir Funktionen oder Ihr Konto oder kündigen wir außerordentlich, informieren wir Sie
-        spätestens mit der Maßnahme per E-Mail über: die Maßnahme und ihre Dauer; die Tatsachen und
-        Umstände, auf die wir uns stützen, einschließlich einer etwaigen Meldung; ob automatisierte
-        Mittel beteiligt waren; die Rechtsvorschrift oder die Ziffer dieser AGB, gegen die verstoßen
-        wurde, mit einer Erläuterung; sowie Ihre Möglichkeiten, die Entscheidung überprüfen zu
-        lassen (Beschwerde nach Ziffer 14.7 und der Rechtsweg zu den Gerichten). Bei irreführenden
-        kommerziellen Inhalten in großem Umfang (Spam) kann die Begründung entfallen (Art. 17 Abs. 2
-        DSA).
+        14.6 Begründung unserer Entscheidungen: Entfernen oder blenden wir einen Nutzerinhalt nach
+        Prüfung durch einen Menschen aus, sperren wir Funktionen oder Ihr Konto oder kündigen wir
+        außerordentlich, informieren wir Sie spätestens mit der Maßnahme per E-Mail über: die
+        Maßnahme und ihre Dauer; die Tatsachen und Umstände, auf die wir uns stützen, einschließlich
+        einer etwaigen Meldung; ob automatisierte Mittel beteiligt waren; die Rechtsvorschrift oder
+        die Ziffer dieser AGB, gegen die verstoßen wurde, mit einer Erläuterung; sowie Ihre
+        Möglichkeiten, die Entscheidung überprüfen zu lassen (Beschwerde nach Ziffer 14.7 und der
+        Rechtsweg zu den Gerichten). Bei einer vorläufigen Ausblendung nach Ziffer 14.4 erhalten Sie
+        diese Information, sobald ein Mensch entschieden hat, dass die Aufgabe ausgeblendet bleibt
+        oder entfernt wird. Bei irreführenden kommerziellen Inhalten in großem Umfang (Spam) kann
+        die Begründung entfallen (Art. 17 Abs. 2 DSA).
       </p>
       <p>
         14.7 Überprüfung: Gegen jede Maßnahme nach den Ziffern 14.3 bis 14.6 und 15 sowie gegen


### PR DESCRIPTION
- `pages/docs/terms-and-conditions.vue`, Ziffer 14.6: the reasoned e-mail for a hidden or removed task is sent once a human has decided that the task stays hidden or is removed; the provisional hide of Ziffer 14.4 is not itself announced. The six elements of the notice and the complaint route (14.7) are unchanged.
- `pages/docs/privacy.vue`, § 10.5: the audited administrative reads are listed completely — data export, user listing, document listing and declaration listing (backend #749).
- `TERMS_VERSION` unchanged; the AGB PDF attachment is regenerated in a backend follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)