### PR TITLE
Fix skill tree centering after panning and zooming

### DIFF
--- a/composables/skilltree.ts
+++ b/composables/skilltree.ts
@@ -105,9 +105,10 @@ export function scrollMapToNode(
       typeof mapRef.getBoundingClientRect === "function" ? mapRef.getBoundingClientRect() : null;
 
     if (rect) {
-      const { scale } = panzoomInstance.getTransform();
-      const targetX = rect.width * 0.5 - cx * scale;
-      const targetY = rect.height * 0.5 - cy * scale;
+      const scale = panzoomInstance.getScale();
+      // Panzoom scales translation too. The early native scroll fallback may still be active.
+      const targetX = (rect.width * 0.5 + (mapRef.scrollLeft ?? 0)) / scale - cx;
+      const targetY = (rect.height * 0.5 + (mapRef.scrollTop ?? 0)) / scale - cy;
       panzoomInstance.pan(targetX, targetY, { animate: smooth });
       return;
     }

--- a/composables/skilltree.ts
+++ b/composables/skilltree.ts
@@ -106,9 +106,14 @@ export function scrollMapToNode(
 
     if (rect) {
       const scale = panzoomInstance.getScale();
-      // Panzoom scales translation too. The early native scroll fallback may still be active.
-      const targetX = (rect.width * 0.5 + (mapRef.scrollLeft ?? 0)) / scale - cx;
-      const targetY = (rect.height * 0.5 + (mapRef.scrollTop ?? 0)) / scale - cy;
+      // Panzoom treats the outer SVG like HTML: a 50% origin and scaled translation.
+      const originX = (ref.ownerSVGElement?.clientWidth ?? 0) * 0.5;
+      const originY = (ref.ownerSVGElement?.clientHeight ?? 0) * 0.5;
+      // Keep the native scroll offset retained while Panzoom was still initializing.
+      const targetX =
+        (rect.width * 0.5 + (mapRef.scrollLeft ?? 0) - originX) / scale + originX - cx;
+      const targetY =
+        (rect.height * 0.5 + (mapRef.scrollTop ?? 0) - originY) / scale + originY - cy;
       panzoomInstance.pan(targetX, targetY, { animate: smooth });
       return;
     }

--- a/tests/skilltree-centering.test.mjs
+++ b/tests/skilltree-centering.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import ts from "typescript";
+
+const source = await readFile(new URL("../composables/skilltree.ts", import.meta.url), "utf8");
+const ast = ts.createSourceFile("skilltree.ts", source, ts.ScriptTarget.Latest, true);
+const declaration = ast.statements.find(
+  (node) => ts.isFunctionDeclaration(node) && node.name?.text === "scrollMapToNode"
+);
+const code = ts.transpileModule(declaration.getText(ast), {
+  compilerOptions: { target: ts.ScriptTarget.ES2023, module: ts.ModuleKind.ESNext },
+}).outputText;
+const { scrollMapToNode } = await import(
+  `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`
+);
+
+function fixture(width = 390, height = 820) {
+  const calls = [];
+  const node = { getAttribute: (name) => ({ x: "840", y: "1260" })[name] };
+  const map = [[node]];
+  const viewport = {
+    clientWidth: width,
+    clientHeight: height,
+    scrollLeft: 0,
+    scrollTop: 0,
+    getBoundingClientRect: () => ({ left: 20, top: 90, width, height }),
+    scroll: (options) => calls.push({ scroll: options }),
+  };
+  return { map, viewport, calls };
+}
+
+for (const scale of [0.4, 1, 1.7, 3]) {
+  test(`selected node is centered at zoom ${scale} using Panzoom's unscaled translation`, () => {
+    const { map, viewport, calls } = fixture();
+    // This is the installed @panzoom/panzoom API: deliberately no getTransform().
+    const panzoom = {
+      getScale: () => scale,
+      pan: (x, y, options) => calls.push({ x, y, options }),
+    };
+    scrollMapToNode(map, viewport, 120, 0, 0, true, panzoom);
+    assert.equal(calls.length, 1);
+    const { x, y, options } = calls[0];
+    // Its SVG transform is scale(s) translate(x,y), with origin 0 0.
+    assert(Math.abs((840 + 60 + x) * scale - viewport.clientWidth / 2) < 1e-9);
+    assert(Math.abs((1260 + 60 + y) * scale - viewport.clientHeight / 2) < 1e-9);
+    assert.deepEqual(options, { animate: true });
+  });
+}
+
+for (const scale of [0.4, 1, 1.7, 3]) {
+  test(`existing native scroll is preserved when centering at zoom ${scale}`, () => {
+    const { map, viewport, calls } = fixture();
+    viewport.scrollLeft = 705;
+    viewport.scrollTop = 910;
+    scrollMapToNode(map, viewport, 120, 0, 0, true, {
+      getScale: () => scale,
+      pan: (x, y) => calls.push({ x, y }),
+    });
+    const { x, y } = calls[0];
+    assert(Math.abs((900 + x) * scale - viewport.scrollLeft - 195) < 1e-9);
+    assert(Math.abs((1320 + y) * scale - viewport.scrollTop - 410) < 1e-9);
+    assert.equal(calls.length, 1);
+  });
+}
+
+test("initial centering keeps animation disabled", () => {
+  const { map, viewport, calls } = fixture(1280, 800);
+  scrollMapToNode(map, viewport, 120, 0, 0, false, {
+    getScale: () => 2,
+    pan: (x, y, options) => calls.push(options),
+  });
+  assert.deepEqual(calls, [{ animate: false }]);
+});
+
+test("uninitialized panzoom retains the existing native scroll fallback", () => {
+  const { map, viewport, calls } = fixture(1280, 800);
+  scrollMapToNode(map, viewport, 120, 0, 0, false);
+  assert.deepEqual(calls, [{ scroll: { left: 260, top: 920, behavior: "auto" } }]);
+});
+
+test("missing node or viewport during setup causes no movement", () => {
+  const { map, viewport, calls } = fixture();
+  scrollMapToNode([], viewport, 120, 0, 0, true);
+  scrollMapToNode([[]], viewport, 120, 0, 0, true);
+  scrollMapToNode(map, null, 120, 0, 0, true);
+  assert.deepEqual(calls, []);
+});

--- a/tests/skilltree-centering.test.mjs
+++ b/tests/skilltree-centering.test.mjs
@@ -17,7 +17,10 @@ const { scrollMapToNode } = await import(
 
 function fixture(width = 390, height = 820) {
   const calls = [];
-  const node = { getAttribute: (name) => ({ x: "840", y: "1260" })[name] };
+  const node = {
+    getAttribute: (name) => ({ x: "840", y: "1260" })[name],
+    ownerSVGElement: { clientWidth: 2700, clientHeight: 3300 },
+  };
   const map = [[node]];
   const viewport = {
     clientWidth: width,
@@ -41,9 +44,9 @@ for (const scale of [0.4, 1, 1.7, 3]) {
     scrollMapToNode(map, viewport, 120, 0, 0, true, panzoom);
     assert.equal(calls.length, 1);
     const { x, y, options } = calls[0];
-    // Its SVG transform is scale(s) translate(x,y), with origin 0 0.
-    assert(Math.abs((840 + 60 + x) * scale - viewport.clientWidth / 2) < 1e-9);
-    assert(Math.abs((1260 + 60 + y) * scale - viewport.clientHeight / 2) < 1e-9);
+    // The outer SVG is treated like HTML: scale(s) translate(x,y), origin 50% 50%.
+    assert(Math.abs((900 - 1350 + x) * scale + 1350 - viewport.clientWidth / 2) < 1e-9);
+    assert(Math.abs((1320 - 1650 + y) * scale + 1650 - viewport.clientHeight / 2) < 1e-9);
     assert.deepEqual(options, { animate: true });
   });
 }
@@ -58,8 +61,8 @@ for (const scale of [0.4, 1, 1.7, 3]) {
       pan: (x, y) => calls.push({ x, y }),
     });
     const { x, y } = calls[0];
-    assert(Math.abs((900 + x) * scale - viewport.scrollLeft - 195) < 1e-9);
-    assert(Math.abs((1320 + y) * scale - viewport.scrollTop - 410) < 1e-9);
+    assert(Math.abs((900 - 1350 + x) * scale + 1350 - viewport.scrollLeft - 195) < 1e-9);
+    assert(Math.abs((1320 - 1650 + y) * scale + 1650 - viewport.scrollTop - 410) < 1e-9);
     assert.equal(calls.length, 1);
   });
 }


### PR DESCRIPTION
Fix skill tree centering when opening or selecting a node. Use Panzoom’s supported scale API and account for its transform origin and the container’s scroll position, so the selected skill stays centered after zooming.

Validation: 400 Node tests passed, one existing skip; format, lint and both static builds passed. Eight desktop/mobile browser cases cover both trees, dragging, zooming in and out, and centering through the visible paths.
