### PR TITLE
Center small skill trees on an existing node

### DIFF
--- a/composables/skilltree.ts
+++ b/composables/skilltree.ts
@@ -75,6 +75,42 @@ export function createPathwaysForTree(map: any, nodes: any[], nodeSize: any) {
   return arr;
 }
 
+export function resolveInitialSkilltreeTarget(
+  nodes: { row: number; column: number }[],
+  preferred: { row: number; column: number } | null | undefined,
+  rows: number,
+  columns: number
+) {
+  const occupied = nodes.filter(
+    (node) =>
+      Number.isInteger(node.row) &&
+      Number.isInteger(node.column) &&
+      node.row >= 0 &&
+      node.column >= 0 &&
+      node.row < rows &&
+      node.column < columns
+  );
+  if (!occupied.length) return null;
+
+  const saved = occupied.find(
+    (node) => node.row === preferred?.row && node.column === preferred?.column
+  );
+  if (saved) return { row: saved.row, column: saved.column };
+
+  const centerRow =
+    (Math.min(...occupied.map((node) => node.row)) +
+      Math.max(...occupied.map((node) => node.row))) /
+    2;
+  const centerColumn =
+    (Math.min(...occupied.map((node) => node.column)) +
+      Math.max(...occupied.map((node) => node.column))) /
+    2;
+  const distance = (node: { row: number; column: number }) =>
+    (node.row - centerRow) ** 2 + (node.column - centerColumn) ** 2;
+  occupied.sort((a, b) => distance(a) - distance(b) || a.row - b.row || a.column - b.column);
+  return { row: occupied[0].row, column: occupied[0].column };
+}
+
 export function scrollMapToNode(
   map: any,
   mapRef: any,

--- a/pages/skill-tree/[id]/index.vue
+++ b/pages/skill-tree/[id]/index.vue
@@ -372,10 +372,13 @@ export default {
           nextTick(() => {
             createPathways();
 
-            let row = nextNode.value.row;
-            let column = nextNode.value.column;
-
-            scrollToNode(row, column, false);
+            const target = resolveInitialSkilltreeTarget(
+              nodes,
+              nextNode.value,
+              totalRows.value,
+              totalColumns.value
+            );
+            if (target) scrollToNode(target.row, target.column, false);
             setupComplete.value = true;
           });
         }

--- a/pages/skill-tree/index.vue
+++ b/pages/skill-tree/index.vue
@@ -275,10 +275,13 @@ export default {
           nextTick(() => {
             createPathways();
 
-            let row = nextNode.value.row;
-            let column = nextNode.value.column;
-
-            scrollToNode(row, column, false);
+            const target = resolveInitialSkilltreeTarget(
+              nodes,
+              nextNode.value,
+              totalRows.value,
+              totalColumns.value
+            );
+            if (target) scrollToNode(target.row, target.column, false);
             setupComplete.value = true;
           });
         }

--- a/tests/skilltree-start-target.test.mjs
+++ b/tests/skilltree-start-target.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { parse } from "@vue/compiler-sfc";
+import ts from "typescript";
+
+const source = await readFile(new URL("../composables/skilltree.ts", import.meta.url), "utf8");
+const ast = ts.createSourceFile("skilltree.ts", source, ts.ScriptTarget.Latest, true);
+const declaration = ast.statements.find(
+  (node) => ts.isFunctionDeclaration(node) && node.name?.text === "resolveInitialSkilltreeTarget"
+);
+const code = ts.transpileModule(declaration.getText(ast), {
+  compilerOptions: { target: ts.ScriptTarget.ES2023, module: ts.ModuleKind.ESNext },
+}).outputText;
+const { resolveInitialSkilltreeTarget: resolve } = await import(
+  `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`
+);
+const nodes = [
+  { row: 0, column: 2 },
+  { row: 2, column: 2 },
+  { row: 2, column: 4 },
+  { row: 4, column: 2 },
+  { row: 4, column: 4 },
+];
+
+test("a saved occupied position is retained even away from the middle", () => {
+  assert.deepEqual(resolve(nodes, { row: 4, column: 4 }, 8, 7), { row: 4, column: 4 });
+});
+
+test("the existing root Start target remains valid", () => {
+  assert.deepEqual(resolve([{ row: 10, column: 10 }], { row: 10, column: 10 }, 20, 20), {
+    row: 10,
+    column: 10,
+  });
+});
+
+test("fresh, stale, empty-cell and malformed targets resolve inside the actual small tree", () => {
+  for (const preferred of [
+    null,
+    { row: 10, column: 10 },
+    { row: 3, column: 3 },
+    { row: "2", column: 2 },
+  ]) {
+    assert.deepEqual(resolve(nodes, preferred, 8, 7), { row: 2, column: 2 });
+  }
+});
+
+test("nearest occupied target is deterministic without changing the API node order", () => {
+  const reverse = [...nodes].reverse();
+  const before = structuredClone(reverse);
+  assert.deepEqual(resolve(reverse, undefined, 8, 7), { row: 2, column: 2 });
+  assert.deepEqual(reverse, before);
+});
+
+test("empty grids and invalid or unrenderable nodes produce no target", () => {
+  assert.equal(resolve([], null, 8, 7), null);
+  assert.equal(resolve(nodes, null, 0, 0), null);
+  assert.equal(
+    resolve(
+      [
+        { row: 8, column: 2 },
+        { row: -1, column: 2 },
+        { row: 2.5, column: 2 },
+      ],
+      null,
+      8,
+      7
+    ),
+    null
+  );
+});
+
+for (const page of ["pages/skill-tree/index.vue", "pages/skill-tree/[id]/index.vue"]) {
+  const sfc = parse(await readFile(new URL(`../${page}`, import.meta.url), "utf8"));
+  const tree = ts.createSourceFile(
+    "page.ts",
+    sfc.descriptor.script.content,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  let watcher;
+  function find(node) {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText(tree) === "watch" &&
+      node.arguments[0]?.getText(tree) === "() => map"
+    )
+      watcher = node.arguments[1];
+    ts.forEachChild(node, find);
+  }
+  find(tree);
+  assert(watcher, `${page} map watcher exists`);
+  const script = ts.transpileModule(`const observe = ${watcher.getText(tree)};`, {
+    compilerOptions: { target: ts.ScriptTarget.ES2023 },
+  }).outputText;
+  for (const [preferred, expected] of [
+    [
+      { row: 10, column: 10 },
+      { row: 2, column: 2 },
+    ],
+    [
+      { row: 4, column: 4 },
+      { row: 4, column: 4 },
+    ],
+  ]) {
+    test(`${page}: actual initialization watcher selects ${JSON.stringify(expected)} for ${JSON.stringify(preferred)}`, () => {
+      const calls = [],
+        setup = { value: false };
+      const observe = new Function(
+        "nextTick",
+        "createPathways",
+        "resolveInitialSkilltreeTarget",
+        "nodes",
+        "nextNode",
+        "totalRows",
+        "totalColumns",
+        "scrollToNode",
+        "setupComplete",
+        `${script}; return observe;`
+      )(
+        (run) => run(),
+        () => {},
+        resolve,
+        nodes,
+        { value: preferred },
+        { value: 8 },
+        { value: 7 },
+        (row, column, smooth) => calls.push({ row, column, smooth }),
+        setup
+      );
+      observe([[{}]]);
+      assert.deepEqual(calls, [{ ...expected, smooth: false }]);
+      assert.equal(setup.value, true);
+    });
+  }
+}


### PR DESCRIPTION
A fresh or outdated saved target could point outside a small skill tree, leaving its content offscreen. Keep a valid target; otherwise center an existing node near the occupied area. Empty trees remain safe.

Validation: 26 focused Node tests, formatting, lint and both frontend builds; 12 local desktop/mobile browser cases cover fresh, invalid and valid saved targets, reload and zoom. The actual Test data layout also passed four public browser views.
